### PR TITLE
adding acs aem tools to touch ui nav. fixes #44

### DIFF
--- a/content/src/main/content/META-INF/vault/filter.xml
+++ b/content/src/main/content/META-INF/vault/filter.xml
@@ -5,4 +5,5 @@
     </filter>
     <filter root="/etc/acs-tools"/>
     <filter root="/etc/clientlibs/acs-tools"/>
+    <filter root="/apps/cq/core/content/nav/acs-tools"/>
 </workspaceFilter>

--- a/content/src/main/content/jcr_root/apps/cq/core/content/nav/acs-tools/.content.xml
+++ b/content/src/main/content/jcr_root/apps/cq/core/content/nav/acs-tools/.content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:OrderedFolder"
+    jcr:title="ACS AEM Tools"
+    id="acs-tools">
+    <aem-fiddle/>
+    <query-editor/>
+    <jsp-code-display/>
+</jcr:root>

--- a/content/src/main/content/jcr_root/apps/cq/core/content/nav/acs-tools/aem-fiddle/.content.xml
+++ b/content/src/main/content/jcr_root/apps/cq/core/content/nav/acs-tools/aem-fiddle/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:description="Fiddle around with AEM"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="AEM Fiddle"
+    href="/etc/acs-tools/aem-fiddle.html"
+    id="acs-tools-fiddle"
+    target="_blank"/>

--- a/content/src/main/content/jcr_root/apps/cq/core/content/nav/acs-tools/jsp-code-display/.content.xml
+++ b/content/src/main/content/jcr_root/apps/cq/core/content/nav/acs-tools/jsp-code-display/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:description="Get to the bottom of JSP stack traces"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="JSP Code Display"
+    href="/etc/acs-tools/jsp-code-display.html"
+    id="acs-tools-jsp-code-display"
+    target="_blank"/>

--- a/content/src/main/content/jcr_root/apps/cq/core/content/nav/acs-tools/query-editor/.content.xml
+++ b/content/src/main/content/jcr_root/apps/cq/core/content/nav/acs-tools/query-editor/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:description="Write QueryBuilder queries with ease"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Query Editor"
+    href="/etc/acs-tools/query-editor.html"
+    id="acs-tools-query-editor"
+    target="_blank"/>


### PR DESCRIPTION
This does the trick (and doesn't break 5.6.1). However, it may cause issues on the public beta version of 6.0, so I'm inclined to let it sit as an open pull request until AEM 6.0 is GA.
