### PR TITLE
Query Editor - Values w spaces bug fix

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-tools/components/query-editor/clientlibs/js/controllers/controller-queryeditor.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/query-editor/clientlibs/js/controllers/controller-queryeditor.js
@@ -60,7 +60,7 @@ angular.module('qeControllers').
 
             function params(source) {
                 var o = {};
-                source.replace(/^\s*(\S*)\s*=\s*(\S+(.*\S+|\S*))\s*$/gm, function ($0, $1, $2) {
+                source.replace(/^\s*(\S*)\s*=\s*(\S+([\w\W]*\S+|\S*))\s*$/gm, function ($0, $1, $2) {
                     o[$1] = $2;
                 });
                 return o;


### PR DESCRIPTION
Fixed regex to all spaces as long as they are bounded by non spaces 

Examples:

```
property.value=foo
property.value=foo bar
property.value=foo bar cat      dog
```

Leading and trailing whitespace around the value are stripped as originally designed.
