### PR TITLE
AEM Tools navigation overlay node types

### DIFF
--- a/content/src/main/content/jcr_root/apps/cq/core/content/.content.xml
+++ b/content/src/main/content/jcr_root/apps/cq/core/content/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:OrderedFolder"/

--- a/content/src/main/content/jcr_root/apps/cq/core/content/nav/.content.xml
+++ b/content/src/main/content/jcr_root/apps/cq/core/content/nav/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="nt:unstructured"/


### PR DESCRIPTION
Package installation error occurs when a package overlays the /apps/cq/core nav structure using the parent /libs node types.

/apps/cq/core/content [sling:OrderedFolder]
/apps/cq/core/content/nav [nt:unstructured]

Provided node defs in ACS Tools package to create these nodes using the above types rather than nf:folder
