### PR TITLE
TPG option to create buckets as Pages

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/tools/test_page_generator/impl/Parameters.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/test_page_generator/impl/Parameters.java
@@ -43,6 +43,8 @@ public class Parameters {
 
     private static final int DEFAULT_BUCKET_SIZE = 100;
 
+    private static final String DEFAULT_BUCKET_TYPE = "sling:Folder";
+
     private final String rootPath;
 
     private final String template;
@@ -52,6 +54,8 @@ public class Parameters {
     private final int bucketSize;
 
     private final int saveThreshold;
+
+    private final String bucketType;
 
     private final Map<String, Object> properties;
 
@@ -65,6 +69,7 @@ public class Parameters {
         template = json.optString("template", "");
         total = json.optInt("total", 0);
         bucketSize = json.optInt("bucketSize", DEFAULT_BUCKET_SIZE);
+        bucketType = json.optString("bucketType", DEFAULT_BUCKET_TYPE);
         saveThreshold = json.optInt("saveThreshold", DEFAULT_SAVE_THRESHOLD);
 
         properties = new HashMap<String, Object>();
@@ -126,6 +131,10 @@ public class Parameters {
         }
     }
 
+    public final String getBucketType() {
+        return StringUtils.defaultIfEmpty(this.bucketType, DEFAULT_BUCKET_TYPE);
+    }
+
     public final int getSaveThreshold() {
         if (saveThreshold > 0) {
             return saveThreshold;
@@ -145,6 +154,7 @@ public class Parameters {
         printWriter.println("Template: " + this.getTemplate());
         printWriter.println("Total Pages to Create: " + this.getTotal());
         printWriter.println("Bucket Size: " + this.getBucketSize());
+        printWriter.println("Bucket Type: " + this.getBucketType());
         printWriter.println("Save Threshold: " + this.getSaveThreshold());
 
         return printWriter.toString();

--- a/bundle/src/main/java/com/adobe/acs/tools/test_page_generator/impl/TestPageGeneratorServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/test_page_generator/impl/TestPageGeneratorServlet.java
@@ -137,7 +137,7 @@ public class TestPageGeneratorServlet extends SlingAllMethodsServlet {
                 bucketCount = 0;
             }
 
-            final String folderPath = this.getOrCreateBucketPath(resourceResolver, rootPath, depthTracker);
+            final String folderPath = this.getOrCreateBucketPath(resourceResolver, parameters, rootPath, depthTracker);
 
             final Page page = createPage(resourceResolver,
                     folderPath,
@@ -228,7 +228,8 @@ public class TestPageGeneratorServlet extends SlingAllMethodsServlet {
      * @return the path to the newly created bucket
      * @throws RepositoryException
      */
-    private String getOrCreateBucketPath(ResourceResolver resourceResolver, String rootPath, int[] depthTracker)
+    private String getOrCreateBucketPath(ResourceResolver resourceResolver, Parameters params, String rootPath, int[]
+            depthTracker)
             throws RepositoryException {
         final Session session = resourceResolver.adaptTo(Session.class);
         String folderPath = rootPath;
@@ -241,8 +242,19 @@ public class TestPageGeneratorServlet extends SlingAllMethodsServlet {
         if (resourceResolver.getResource(folderPath) != null) {
             return folderPath;
         } else {
-            Node node = JcrUtil.createPath(folderPath, NT_SLING_FOLDER, NT_SLING_FOLDER, session, false);
-            log.debug("Created new folder path at [ {} ]", node.getPath());
+            Node node;
+
+            if (StringUtils.equals(NT_SLING_FOLDER, params.getBucketType())) {
+                // Create bucket structure as sling:Folders
+                node = JcrUtil.createPath(folderPath, NT_SLING_FOLDER, NT_SLING_FOLDER, session, false);
+                log.debug("Created new folder path at [ {} ]", node.getPath());
+            } else {
+                // Create bucket structure as cq:Pages
+                node = JcrUtil.createPath(folderPath, NameConstants.NT_PAGE, NameConstants.NT_PAGE, session, false);
+                JcrUtil.createPath(folderPath + "/jcr:content", NameConstants.NT_PAGE, "cq:PageContent",
+                        session, false);
+            }
+
             return node.getPath();
         }
     }

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/test-page-generator/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/test-page-generator/clientlibs/js/app.js
@@ -30,8 +30,9 @@ angular.module('testPageGeneratorApp',[]).controller('MainCtrl', ['$scope', '$ht
     $scope.notifications = [];
 
     $scope.form = {
+        bucketType: 'sling:Folder',
         properties: [
-            { name: '', value: '', multi: false }
+            {name: '', value: '', multi: false}
         ]
     };
 

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/test-page-generator/includes/form.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/test-page-generator/includes/form.jsp
@@ -70,6 +70,26 @@
     </div>
 
     <div class="form-row">
+        <h4>Bucket Type</h4>
+
+        <span>
+            <select ng-model="form.bucketType">
+                <option value="sling:Folder">Folder</option>
+                <option value="cq:Page">Page</option>
+            </select>
+        </span>
+    </div>
+
+    <div class="form-row"
+            ng-show="form.bucketType === 'cq:Page'">
+        <div class="instructions">
+            <p>
+                Bucket pages are NOT included in the total pages to generate.
+            </p>
+        </div>
+    </div>
+
+    <div class="form-row">
         <h4>Save Threshold</h4>
 
         <span>


### PR DESCRIPTION
Allows user to select a Bucket Type: Folder (sling:Folder) or Page (cq:Page)

![test_page_generator___acs_aem_tools_and_acs-aem-tools_ _acs](https://cloud.githubusercontent.com/assets/1451868/5483107/e39333ea-863a-11e4-988f-cc1f8c0af81d.png)

![crxde_lite](https://cloud.githubusercontent.com/assets/1451868/5483125/0bedc8c8-863b-11e4-86f5-3068dbfea84e.png)

Fixes #81 
