### PR TITLE
VLT-RCP Enchancements

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/.content.xml
@@ -2,6 +2,6 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     cq:defaultView="html"
     jcr:primaryType="cq:Component"
-    jcr:title="VTL-RCP Page Component"
+    jcr:title="VLT-RCP"
     sling:resourceSuperType="foundation/components/page"
     componentGroup=".hidden"/>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/.content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
-    categories="[vlt-rcp.app]"
-    dependencies="[coralui,acs-tools.ace,acs-tools.angularjs,acs-tools.angularui.ace,acs-tools.ngDialog,underscore]"/>
+    categories="[acs-tools.vlt-rcp.app]"
+    dependencies="[coralui,acs-tools.ace,acs-tools.angularjs,acs-tools.ngDialog,underscore]"/>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
     categories="[acs-tools.vlt-rcp.app]"
-    dependencies="[coralui,acs-tools.ace,acs-tools.angularjs,acs-tools.ngDialog,underscore]"/>
+    dependencies="[coralui,acs-tools.angularjs,acs-tools.ngDialog]"/>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/css/style.less
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/css/style.less
@@ -68,13 +68,16 @@
 
   .create-new-task {
     width: 80%;
-    margin: auto 0;
 
     .label-col {
       width: 10em;
       padding-right: 1em;
       font-weight: bold;
       text-align: right;
+
+      label {
+        line-height: 1.5em;
+      }
     }
 
     .field-col {

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/css/style.less
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/css/style.less
@@ -18,46 +18,111 @@
  * #L%
  */
 
-#acs-tools-vlt-rcp {
+#acs-tools-vlt-rcp-app-css {
 
-    .page {
-        padding-bottom: 1.5rem;
+  .content-container {
+    width: 100%;
+
+    .content-container-inner {
+      width: 960px;
+      margin: 0 auto;
+    }
+  }
+
+  .drawer {
+    padding-left: 1em;
+
+    input[type=checkbox] {
+      opacity: 1;
+      margin-top: -10px;
+      margin-left: 5px;
+      margin-right: 2em
+    }
+  }
+
+  .notifications {
+    position: fixed;
+    top: 50px;
+    left: 0;
+    right: 0;
+    margin: 0 auto;
+    width: 960px;
+    z-index: 1000;
+  }
+
+  .tasks {
+    width: 100%;
+
+    td {
+      text-align: left;
+      vertical-align: top;
     }
 
-    /* header */
-
-    header > .drawer > button {
-        margin-top: 7px;
-    }
-
-    ul.list-unstyled li {
-   	    list-style-type: none;
-	}
-	
-    .opaque {
-        opacity : 1;
-    }
-    
-    .fullwidth {
-       width: 100%;
-    }
-
-    table.data {
-      tr td {
-        vertical-align: top;
+    td.actions {
+      text-align: center;
+      .action-button {
+        margin: 10px auto;
       }
-      
-      td.num {
-        text-align: left;
+    }
+  }
+
+  .create-new-task {
+    width: 80%;
+    margin: auto 0;
+
+    .label-col {
+      width: 10em;
+      padding-right: 1em;
+      font-weight: bold;
+      text-align: right;
+    }
+
+    .field-col {
+      text-align: left;
+    }
+
+    input[type=text] {
+      width: 100%;
+    }
+
+    .add-remove-list {
+
+      .add {
+        margin-top: 5px;
+
+        a {
+          color: #000;
+
+          &:hover {
+            text-decoration: underline;
+          }
+        }
       }
 
-      tr td div {
-        max-height: 5em;
-        overflow-y: hidden;
+      .remove {
+        margin: 10px
       }
 
-      tr.expanded td div {
-        max-height: initial;
+      ul {
+        list-style: none;
+        margin: 1em 0;
+        padding :0;
+
+        li {
+          margin: 0;
+          padding: 0 0 .5em 0;
+
+          input[type=text] {
+            width: 90%;
+          }
+        }
       }
     }
+  }
+}
+
+.ngdialog.ngdialog-theme-default {
+  padding-top: 45px !important;
+  padding-bottom: 10px !important;
+
 }

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
@@ -28,18 +28,18 @@ vltApp.controller('MainCtrl', function ($scope, $http, $timeout, $interval, $q, 
 
     $scope.rcp_uri = '/libs/granite/packaging/rcp';
 
-    $scope.task_src = 'http://admin:admin@localhost:4502/crx/server/-/jcr:root/content/dam/geometrixx';
+    $scope.task_src = 'http://admin:admin@localhost:4502/crx/server/-/jcr:root/content/dam/my-site';
 
-    $scope.task_dst = '/content/dam/geometrixx2';
+    $scope.task_dst = '/content/dam/my-site';
 
-    $scope.task_batchSize = "2048";
+    $scope.task_batchSize = '1024';
 
-    $scope.task_throttle = "1";
+    $scope.task_throttle = '';
 
     $scope.checkboxModel = {
-        recursive: true,
-        update: true,
-        onlyNewer: true,
+        recursive: false,
+        update: false,
+        onlyNewer: false,
         noOrdering: false,
         autoRefresh: false
     };
@@ -168,18 +168,20 @@ vltApp.controller('MainCtrl', function ($scope, $http, $timeout, $interval, $q, 
     };
 
     $scope.confirm = function () {
-        var i = 0, excludes = [], cmd = {
-            "cmd": "create",
-            "id": $scope.task_id,
-            "src": $scope.task_src,
-            "dst": $scope.task_dst,
-            "batchsize": $scope.task_batchSize,
-            "update": $scope.checkboxModel.update,
-            "onlyNewer": $scope.checkboxModel.onlyNewer,
-            "recursive": $scope.checkboxModel.recursive,
-            "noOrdering": $scope.checkboxModel.noOrdering,
-            "throttle": $scope.task_throttle
-        };
+        var i = 0,
+            excludes = [],
+            cmd = {
+                "cmd": "create",
+                "id": $scope.task_id,
+                "src": $scope.task_src,
+                "dst": $scope.task_dst,
+                "batchsize": $scope.task_batchSize || 1024,
+                "update": $scope.checkboxModel.update,
+                "onlyNewer": $scope.checkboxModel.onlyNewer,
+                "recursive": $scope.checkboxModel.recursive,
+                "noOrdering": $scope.checkboxModel.noOrdering,
+                "throttle": $scope.task_throttle || 0
+            };
 
         if ($scope.task_resumeFrom !== "") {
             cmd.resumeFrom = $scope.task_resumeFrom;

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
@@ -18,29 +18,31 @@
  * #L%
  */
 
-/*global angular: false, ace: false */
+/*global angular: false */
 
-var vltApp = angular.module('vltApp',['ngDialog']);
+var vltApp = angular.module('vltRcpApp', ['ngDialog']);
 
-vltApp.controller('MainCtrl', function($scope, $http, $timeout, $interval, ngDialog) {
-	
-	$scope.rcp_uri = '/system/jackrabbit/filevault/rcp';
-	
-	$scope.task_src = 'http://admin:admin@localhost:4502/crx/server/-/jcr:root/content/dam/geometrixx';
+vltApp.controller('MainCtrl', function ($scope, $http, $timeout, $interval, $q, ngDialog) {
 
-	$scope.task_dst = '/content/dam/geometrixx2';
+    $scope.rcp_uris = ['/libs/granite/packaging/rcp', '/system/jackrabbit/filevault/rcp'];
 
-	$scope.task_batchSize = "2048";
+    $scope.rcp_uri = '/libs/granite/packaging/rcp';
 
-	$scope.task_throttle = "1";
+    $scope.task_src = 'http://admin:admin@localhost:4502/crx/server/-/jcr:root/content/dam/geometrixx';
 
-	$scope.checkboxModel = {
-        recursive : true,
-        update : true,
-        onlyNewer : true,
-        noOrdering : false,
-        autoRefresh : false
-	};
+    $scope.task_dst = '/content/dam/geometrixx2';
+
+    $scope.task_batchSize = "2048";
+
+    $scope.task_throttle = "1";
+
+    $scope.checkboxModel = {
+        recursive: true,
+        update: true,
+        onlyNewer: true,
+        noOrdering: false,
+        autoRefresh: false
+    };
     $scope.app = {
         uri: '',
         running: false
@@ -49,31 +51,51 @@ vltApp.controller('MainCtrl', function($scope, $http, $timeout, $interval, ngDia
     $scope.notifications = [];
 
     $scope.tasks = [];
-    
+
     $scope.excludes = [];
-    
+
+    $scope.vltMissing = true;
 
     /*
      * Loads the tasks
      */
-    $scope.init = function() {
-        $http({
-            method: 'GET',
-            url: $scope.rcp_uri,
-            params: { ck: (new Date()).getTime() }
-        }).
-        success(function(data, status, headers, config) {
-            $scope.tasks = data.tasks || [];
-        }).
-        error(function(data, status, headers, config) {
-            $scope.addNotification('error', 'ERROR', 'Could not retrieve tasks.');
+    $scope.init = function () {
+
+        angular.forEach($scope.rcp_uris, function (uri) {
+
+            $http.get(uri,
+                {
+                    params: {ck: (new Date()).getTime()}
+                }
+            ).
+                success(function (data, status, headers, config) {
+                    if (status === 200) {
+                        $scope.rcp_uri = uri;
+                        $scope.vltMissing = false;
+                        $scope.tasks = data.tasks || [];
+                    }
+                });
         });
     };
-    
+
+    $scope.refresh = function () {
+        $http.get($scope.rcp_uri,
+            {
+                params: {ck: (new Date()).getTime()}
+            }
+        ).
+            success(function (data, status, headers, config) {
+                $scope.tasks = data.tasks || [];
+            })
+            .error(function (data, status, headers, config) {
+                $scope.addNotification('error', 'ERROR', 'Could not refresh tasks.');
+            });
+    };
+
     $scope.addNotification = function (type, title, message) {
         var timeout = 10000;
 
-        if(type === 'success')  {
+        if (type === 'success') {
             timeout = timeout / 2;
         }
 
@@ -83,7 +105,7 @@ vltApp.controller('MainCtrl', function($scope, $http, $timeout, $interval, ngDia
             message: message
         });
 
-        $timeout(function() {
+        $timeout(function () {
             $scope.notifications.shift();
         }, timeout);
     };
@@ -91,63 +113,63 @@ vltApp.controller('MainCtrl', function($scope, $http, $timeout, $interval, ngDia
     /*
      * Start task
      */
-    $scope.start = function(task) {
+    $scope.start = function (task) {
         var cmd = {
-            "cmd":"start",
+            "cmd": "start",
             "id": task.id
         };
-    
+
         $http.post($scope.rcp_uri, cmd).
-        success(function(data, status, headers, config) {
-            $scope.addNotification('info', 'INFO', 'Task '+task.id+' started.');
-            $scope.init();
-        }).
-        error(function(data, status, headers, config) {
-            $scope.addNotification('error', 'ERROR', 'Could not retrieve tasks.');
-        });
+            success(function (data, status, headers, config) {
+                $scope.addNotification('info', 'INFO', 'Task ' + task.id + ' started.');
+                $scope.refresh();
+            }).
+            error(function (data, status, headers, config) {
+                $scope.addNotification('error', 'ERROR', 'Could not retrieve tasks.');
+            });
     };
 
     /*
      * Stop task
      */
-    $scope.stop = function(task) {
+    $scope.stop = function (task) {
         var cmd = {
-            "cmd":"stop",
+            "cmd": "stop",
             "id": task.id
         };
-    
+
         $http.post($scope.rcp_uri, cmd).
-        success(function(data, status, headers, config) {
-            $scope.addNotification('info', 'INFO', 'Task '+task.id+' stopped.');
-            $scope.init();
-        }).
-        error(function(data, status, headers, config) {
-            $scope.addNotification('error', 'ERROR', 'Could not retrieve tasks.');
-        });
+            success(function (data, status, headers, config) {
+                $scope.addNotification('info', 'INFO', 'Task ' + task.id + ' stopped.');
+                $scope.refresh();
+            }).
+            error(function (data, status, headers, config) {
+                $scope.addNotification('error', 'ERROR', 'Could not retrieve tasks.');
+            });
     };
 
     /*
      * Remove task
      */
-    $scope.remove = function(task) {
+    $scope.remove = function (task) {
         var cmd = {
-            "cmd":"remove",
+            "cmd": "remove",
             "id": task.id
         };
-    
+
         $http.post($scope.rcp_uri, cmd).
-        success(function(data, status, headers, config) {
-            $scope.addNotification('info', 'INFO', 'Task '+task.id+' removed.');
-            $scope.init();
-        }).
-        error(function(data, status, headers, config) {
-            $scope.addNotification('error', 'ERROR', 'Could not retrieve tasks.');
-        });
+            success(function (data, status, headers, config) {
+                $scope.addNotification('info', 'INFO', 'Task ' + task.id + ' removed.');
+                $scope.refresh();
+            }).
+            error(function (data, status, headers, config) {
+                $scope.addNotification('error', 'ERROR', 'Could not retrieve tasks.');
+            });
     };
-    
-    $scope.confirm = function() {
-        var i=0, excludes = [], cmd = {
-            "cmd":"create",
+
+    $scope.confirm = function () {
+        var i = 0, excludes = [], cmd = {
+            "cmd": "create",
             "id": $scope.task_id,
             "src": $scope.task_src,
             "dst": $scope.task_dst,
@@ -158,55 +180,56 @@ vltApp.controller('MainCtrl', function($scope, $http, $timeout, $interval, ngDia
             "noOrdering": $scope.checkboxModel.noOrdering,
             "throttle": $scope.task_throttle
         };
-        
+
         if ($scope.task_resumeFrom !== "") {
             cmd.resumeFrom = $scope.task_resumeFrom;
         }
-        
+
         if ($scope.excludes.length > 0) {
-            for (;i<$scope.excludes.length; i++){
+            for (; i < $scope.excludes.length; i++) {
                 excludes.push($scope.excludes[i].value);
             }
             cmd.excludes = excludes;
         }
-    
+
         $http.post($scope.rcp_uri, cmd).
-        success(function(data, status, headers, config) {
-            $scope.addNotification('info', 'INFO', 'Task created.');
-            $scope.closeThisDialog();
-        }).
-        error(function(data, status, headers, config) {
-            $scope.addNotification('error', 'ERROR', 'Could not create the tasks.');
-        });
+            success(function (data, status, headers, config) {
+                $scope.addNotification('info', 'INFO', 'Task created.');
+                $scope.closeThisDialog();
+            }).
+            error(function (data, status, headers, config) {
+                $scope.addNotification('error', 'ERROR', 'Could not create the tasks.');
+            });
     };
 
 
     /*
      * Create task
      */
-    $scope.createTask = function() {
-        ngDialog.open({ template: 'createTaskTemplate', controller: 'MainCtrl' });
+    $scope.createTask = function () {
+        ngDialog.open({template: 'createTaskTemplate', controller: 'MainCtrl'});
     };
 
-    $scope.addExclude = function() {
-        $scope.excludes.push({ value: "" }); 
+    $scope.addExclude = function () {
+        $scope.excludes.push({value: ""});
     };
-    
-    $scope.removeExclude = function(index){
+
+    $scope.removeExclude = function (index) {
         $scope.excludes.splice(index, 1);
     };
-    
+
     $scope.$on('ngDialog.opened', function (event, $dialog) {
         $dialog.find('.ngdialog-content').css('width', '80%');
+
     });
 
     $scope.$on('ngDialog.closed', function (event, $dialog) {
-        $scope.init();
+        $scope.refresh();
     });
-    
-    $interval(function(){
+
+    $interval(function () {
         if ($scope.checkboxModel.autoRefresh) {
-          $scope.init();
+            $scope.refresh();
         }
-    },5000);
+    }, 5000);
 });

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-template.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-template.jsp
@@ -121,20 +121,18 @@
                     <input type="text"
                            ng-model="task_batchSize"
                            name="resumeFrom"
-                           placeholder="2048"
-                           size="5"/>
+                           placeholder="2048"/>
                 </td>
             </tr>
             <tr>
                 <td class="label-col">
-                    <label>Throttle<br/>(in seconds)</label>
+                    <label>Throttle</label>
                 </td>
                 <td class="field-col">
                     <input type="text"
                            ng-model="task_throttle"
                            name="throttle"
-                           placeholder="1"
-                           size="2"/>
+                           placeholder="in seconds"/>
                 </td>
             </tr>
 

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-template.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-template.jsp
@@ -41,7 +41,7 @@
                     <input type="text"
                            ng-model="task_src"
                            name="src"
-                           placeholder="http://admin:admin@localhost:4502/crx/server/-/jcr:root/content/dam/geometrixx"/>
+                           placeholder="http://admin:admin@localhost:4502/crx/server/-/jcr:root/content/dam/my-site"/>
                 </td>
             </tr>
             <tr>
@@ -52,7 +52,7 @@
                     <input type="text"
                            ng-model="task_dst"
                            name="dst"
-                           placeholder="/content/geometrixx2"/></td>
+                           placeholder="/content/dam/my-site"/></td>
             </tr>
             <tr>
                 <td class="label-col">
@@ -62,7 +62,7 @@
                     <label class="switch">
                         <input type="checkbox"
                                name="recursive"
-                               ng-model="checkboxModel.noOrecursiverdering"><span>No</span><span>Yes</span>
+                               ng-model="checkboxModel.recursive"><span>No</span><span>Yes</span>
                     </label>
                 </td>
             </tr>
@@ -110,7 +110,7 @@
                     <input type="text"
                            ng-model="task_resumeFrom"
                            name="resumeFrom"
-                           placeholder="/content/geometrixx2"/>
+                           placeholder="/content/dam/my-site"/>
                 </td>
             </tr>
             <tr>
@@ -127,7 +127,7 @@
             </tr>
             <tr>
                 <td class="label-col">
-                    <label>Throttle</label>
+                    <label>Throttle<br/>(in seconds)</label>
                 </td>
                 <td class="field-col">
                     <input type="text"
@@ -156,7 +156,7 @@
                             <li>
                                 <input type="text"
                                         ng-model="exclude.value"
-                                        placeholder="/content/geometrixx/(en|fr)/tools(/.*)?"/>
+                                        placeholder="/content/dam/my-site/(en|fr)/documents(/.*)?"/>
 
                                 <a ng-click="removeExclude($index)" class="remove icon-minus-circle"></a>
                             </li>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-template.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-template.jsp
@@ -121,7 +121,7 @@
                     <input type="text"
                            ng-model="task_batchSize"
                            name="resumeFrom"
-                           placeholder="2048"/>
+                           placeholder="1024"/>
                 </td>
             </tr>
             <tr>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-template.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-template.jsp
@@ -1,0 +1,184 @@
+<%--
+  ~ #%L
+  ~ ACS AEM Tools Bundle
+  ~ %%
+  ~ Copyright (C) 2015 Adobe
+  ~ %%
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ #L%
+  --%>
+
+<script type="text/ng-template" id="createTaskTemplate">
+    <h1>Create a new task</h1>
+
+    <form name="myForm" ng-controller="MainCtrl">
+        <table class="create-new-task">
+            <tr>
+                <td class="label-col">
+                    <label>Task Id</label>
+                </td>
+                <td class="field-col">
+                    <input type="text"
+                           ng-model="task_id"
+                           name="id"/>
+                </td>
+            </tr>
+            <tr>
+                <td class="label-col">
+                    <label>Source</label>
+                </td>
+                <td class="field-col">
+                    <input type="text"
+                           ng-model="task_src"
+                           name="src"
+                           placeholder="http://admin:admin@localhost:4502/crx/server/-/jcr:root/content/dam/geometrixx"/>
+                </td>
+            </tr>
+            <tr>
+                <td class="label-col">
+                    <label>Destination</label>
+                </td>
+                <td class="field-col">
+                    <input type="text"
+                           ng-model="task_dst"
+                           name="dst"
+                           placeholder="/content/geometrixx2"/></td>
+            </tr>
+            <tr>
+                <td class="label-col">
+                    <label>Recursive</label>
+                </td>
+                <td class="field-col">
+                    <label class="switch">
+                        <input type="checkbox"
+                               name="recursive"
+                               ng-model="checkboxModel.noOrecursiverdering"><span>No</span><span>Yes</span>
+                    </label>
+                </td>
+            </tr>
+            <tr>
+                <td class="label-col">
+                    <label>Update</label>
+                </td>
+                <td class="field-col">
+                    <label class="switch">
+                        <input type="checkbox"
+                               name="update"
+                               ng-model="checkboxModel.update"><span>No</span><span>Yes</span>
+                    </label>
+                </td>
+            </tr>
+            <tr>
+                <td class="label-col">
+                    <label>Only newer</label>
+                </td>
+                <td class="field-col">
+                    <label class="switch">
+                        <input type="checkbox"
+                               name="onlyNewer"
+                               ng-model="checkboxModel.onlyNewer"><span>No</span><span>Yes</span>
+                    </label>
+                </td>
+            </tr>
+            <tr>
+                <td class="label-col">
+                    <label>No ordering</label>
+                </td>
+                <td class="field-col">
+                    <label class="switch">
+                        <input type="checkbox"
+                               name="noOrdering"
+                               ng-model="checkboxModel.noOrdering"><span>No</span><span>Yes</span>
+                    </label>
+                </td>
+            </tr>
+            <tr>
+                <td class="label-col">
+                    <label>Resume from</label>
+                </td>
+                <td class="field-col">
+                    <input type="text"
+                           ng-model="task_resumeFrom"
+                           name="resumeFrom"
+                           placeholder="/content/geometrixx2"/>
+                </td>
+            </tr>
+            <tr>
+                <td class="label-col">
+                    <label>Batch size</label>
+                </td>
+                <td class="field-col">
+                    <input type="text"
+                           ng-model="task_batchSize"
+                           name="resumeFrom"
+                           placeholder="2048"
+                           size="5"/>
+                </td>
+            </tr>
+            <tr>
+                <td class="label-col">
+                    <label>Throttle</label>
+                </td>
+                <td class="field-col">
+                    <input type="text"
+                           ng-model="task_throttle"
+                           name="throttle"
+                           placeholder="1"
+                           size="2"/>
+                </td>
+            </tr>
+
+            <tr>
+                <td class="label-col" valign="top">
+                    <label>Excludes</label>
+                </td>
+
+                <td class="field-col" style="padding-top: .75em">
+
+                    <div>
+                        <a class="add" ng-click="addExclude()">
+                            <i class="icon-add-circle withLabel">Add exclude rule</i>
+                        </a>
+                    </div>
+
+                    <div class="add-remove-list" ng-show="excludes.length > 0">
+                        <ul ng-repeat="exclude in excludes track by $index">
+                            <li>
+                                <input type="text"
+                                        ng-model="exclude.value"
+                                        placeholder="/content/geometrixx/(en|fr)/tools(/.*)?"/>
+
+                                <a ng-click="removeExclude($index)" class="remove icon-minus-circle"></a>
+                            </li>
+                        </ul>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>
+
+                    <hr/>
+
+                    <button class="primary"
+                            ng-click="confirm()">Create New Task</button>
+
+                    <a class="button"
+                       role="button"
+                       href="#"
+                       ng-click="closeThisDialog()">Cancel</a>
+                </td>
+            </tr>
+        </table>
+    </form>
+</script>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/notifications.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/notifications.jsp
@@ -1,0 +1,30 @@
+<%--
+  ~ #%L
+  ~ ACS AEM Tools Bundle
+  ~ %%
+  ~ Copyright (C) 2015 Adobe
+  ~ %%
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ #L%
+  --%>
+
+<div class="notifications" ng-show="notifications.length > 0">
+    <div ng-repeat="notification in notifications">
+        <div class="alert {{ notification.type }}">
+            <button class="close" data-dismiss="alert">&times;</button>
+            <strong>{{ notification.title }}</strong>
+
+            <div>{{ notification.message }}</div>
+        </div>
+    </div>
+</div>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/vlt-rcp.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/vlt-rcp.jsp
@@ -18,161 +18,199 @@
   #L%
   --%>
 
-<%@include file="/libs/foundation/global.jsp"%>
-<%
-    final String faviconPath = resourceResolver.map(component.getPath() + "/clientlibs/images/favicon.png");
-%>
+<%@include file="/libs/foundation/global.jsp" %><%
+    pageContext.setAttribute("favicon", resourceResolver.map(component.getPath() + "/clientlibs/images/favicon.png"));
 
-<!doctype html>
-<html ng-app="vltApp">
-<head>
-<meta charset="UTF-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+%><!doctype html>
+<html>
 
-<title>VLT-RCP | ACS AEM Tools</title>
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <title>VLT-RCP | ACS AEM Tools</title>
+        <link rel="shortcut icon" href="${favicon}"/>
+        <cq:includeClientLib css="acs-tools.vlt-rcp.app"/>
+    </head>
 
-<link rel="shortcut icon" href="<%= faviconPath %>" />
+    <body id="acs-tools-vlt-rcp-app-css">
 
-<cq:includeClientLib css="vlt-rcp.app" />
+        <div id="acs-tools-vlt-rcp-app" ng-controller="MainCtrl">
+            <header class="top">
 
-</head>
+                <div class="logo">
+                    <a href="/"><i class="icon-marketingcloud medium"></i></a> <span
+                        ng-show="running" class="spinner icon-spinner medium"></span>
+                </div>
 
-<body id="acs-tools-vlt-rcp">
+                <nav class="crumbs">
+                    <a href="/miscadmin">Tools</a> <a
+                        href="${currentPage.path}.html">VLT-RCP</a>
+                </nav>
 
-	<div id=vltApp" ng-controller="MainCtrl">
-		<header class="top">
+                <div class="drawer theme-dark">
+                    <label>Auto refresh </label><input type="checkbox" ng-model="checkboxModel.autoRefresh">
+                    <a href="#" class="icon-add medium" ng-click="createTask()"></a>
+                </div>
+            </header>
 
-			<div class="logo">
-				<a href="/"><i class="icon-marketingcloud medium"></i></a> <span
-					ng-show="running" class="spinner icon-spinner medium"></span>
-			</div>
+            <div class="page" role="main" ng-init="init();">
 
-			<nav class="crumbs">
-				<a href="/miscadmin">Tools</a> <a
-					href="<%= currentPage.getPath() %>.html">VLT-RCP</a>
-			</nav>
+                <cq:include script="includes/notifications.jsp"/>
 
-	        <div class="drawer theme-dark">	
-	            <label>Auto refresh </label><input class="opaque" type="checkbox" ng-model="checkboxModel.autoRefresh">
-	            <a href="#" class="icon-add medium" ng-click="createTask()"></a>
-	        </div>
-		</header>
 
-		<div class="page" role="main" ng-init="init();">
-			<div class="content">
-				<div class="section" ng-show="tasks.length == 0">
+                <div class="content">
+                    <div class="content-container">
+                        <div class="content-container-inner">
 
-					<h2>No Task defined</h2>
+                            <h1>VLT-RCP Web UI</h1>
 
-					<p>Click on <a href="#" class="icon-add medium" ng-click="createTask()"></a> to create a task</p>
+                            <%-- VLT-RCP 3.1.6+ Not installed --%>
+                            <div ng-show="vltMissing">
+                                <div class="alert error large">
+                                    <strong>VLT-RCP 3.1.6+ Missing or Inactive</strong>
+                                    <div>
+                                        VLT-RCP endpoint could not be reached.
 
-				</div>
+                                        <ol>
+                                            <li>
+                                                <a href="http://mirrors.ibiblio.org/maven2/org/apache/jackrabbit/vault/org.apache.jackrabbit.vault.rcp"
+                                                   target="_blank">Download and install</a>
+                                                VLT-RCP on this AEM instance.
+                                            </li>
+                                            <li>Ensure the Apache Jackrabbit FileVault RCP Server Bundle is
+                                                <a href="/system/console/bundles"
+                                                   x-cq-linkchecker="skip"
+                                                   target="_blank">Active</a>.</li>
+                                        </ol>
+                                    </div>
+                                </div>
+                            </div>
 
-				<div class="section" ng-show="tasks.length > 0">
+                            <div ng-show="!vltMissing">
+                                <div class="section" ng-show="tasks.length == 0">
 
-					<h2>Current Tasks</h2>
+                                    <%-- No Tasks Defined --%>
+                                    <div class="alert notice large">
+                                        <strong>No tasks defined</strong>
+                                        <div>
+                                            No VLT-RCP tasks have been defined.
 
-					<p>Click on a task below to view the current status</p>
+                                            <ul>
+                                                <li><a ng-click="createTask()">Create a new VLT-RCP task</a>.</li>
+                                            </ul>
 
-					<table class="data fullwidth">
-						<thead>
-							<tr>
-								<th>ID</th>
-								<th>Status</th>
-								<th>Settings</th>
-								<th>Action</th>
-							</tr>
-						</thead>
+                                        </div>
+                                    </div>
 
-						<tbody>
-							<tr ng-repeat="task in tasks"
-								ng-class="{ expanded : task.expanded }">
-								<td class="num">
-									<div>{{ task.id }}</div>
-								</td>
-								<td class="num">
-									<div>{{ task.status.state }}</div>
-									<div ng-show="task.expanded">
-										Current Path: {{ task.status.currentPath }}<br>
-										Last Saved Path: {{ task.status.lastSavedPath }}<br>
-										Total Nodes: {{ task.status.totalNodes }}<br>
-										Total Size: {{ task.status.totalSize }}<br>
-										Current Size: {{ task.status.currentSize }}<br>
-										Current Nodes: {{ task.status.currentNodes }}<br>
-									</div>
-								</td>
-								<td class="num">
-									<div>
-										Source: {{ task.src }}<br>
-										Destination: {{ task.dst }}<br>
-									</div>
-									<div ng-show="task.expanded">
-										Recursive: {{ task.recursive }}<br>
-										Batch Size: {{ task.batchsize }}<br>
-										Update: {{ task.update }}<br>
-										Only Newer: {{ task.onlyNewer }}<br>
-										No ordering: {{ task.noOrdering }}<br>
-										Throttle: {{ task.throttle }}<br>
-										Resume from: {{ task.resumeFrom }}<br>
-										<div ng-show="task.excludes.length > 0">Excludes:<br>
-										 <span ng-repeat="exclude in task.excludes">{{exclude}}<br></span>
-										</div>
-									</div>
-								</td>
-								<td><a href="#" ng-click="task.expanded = !task.expanded"
-									ng-class="task.expanded ? 'icon-treecollapse' : 'icon-treeexpand'">
-								</a><a href="#" ng-show="task.status.state == 'NEW'" ng-click="start(task)"
-									class="icon-play-circle">
-								</a><a href="#" ng-show="task.status.state == 'RUNNING'" ng-click="stop(task)"
-									class="icon-stop">
-								</a><a href="#" ng-click="remove(task)"
-									class="icon-delete">
-								</a></td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-                <div ng-show="notifications.length > 0">
-                    <div ng-repeat="notification in notifications">
-                        <div class="alert {{ notification.type }}">
-                            <button class="close" data-dismiss="alert">&times;</button>
-                            <strong>{{ notification.title }}</strong>
+                                </div>
 
-                            <div>{{ notification.message }}</div>
+                                <%-- Tasks Defined --%>
+                                <div class="section" ng-show="tasks.length > 0">
+
+                                    <h2>Current Tasks</h2>
+
+                                    <p>
+                                        Click on the <i class="icon-play-circle"></i> to view the details for each Task.
+                                    </p>
+
+                                    <table class="data tasks">
+                                        <thead>
+                                            <tr>
+                                                <th>Task Id</th>
+                                                <th>Status</th>
+                                                <th>Settings</th>
+                                                <th>Actions</th>
+                                            </tr>
+                                        </thead>
+
+                                        <tbody>
+                                            <tr ng-repeat="task in tasks"
+                                                ng-class="{ expanded : task.expanded }">
+                                                <td>
+                                                    {{ task.id }}
+                                                </td>
+
+                                                <td>
+                                                    <div>{{ task.status.state }}</div>
+                                                    <div ng-show="task.expanded">
+
+                                                        <ul>
+                                                            <li>Current path: {{ task.status.currentPath }}</li>
+                                                            <li>Last saved path: {{ task.status.lastSavedPath }}</li>
+                                                            <li>Total nodes: {{ task.status.totalNodes }}</li>
+                                                            <li>Total size: {{ task.status.totalSize }}</li>
+                                                            <li>Current size: {{ task.status.currentSize }}</li>
+                                                            <li>Current nodes: {{ task.status.currentNodes }}</li>
+                                                        </ul>
+                                                    </div>
+                                                </td>
+                                                <td>
+                                                    <ul>
+                                                        <li>Source: {{ task.src }}</li>
+                                                        <li>Destination: {{ task.dst }}</li>
+                                                    </ul>
+
+                                                    <ul ng-show="task.expanded">
+                                                        <li>Recursive: {{ task.recursive }}</li>
+                                                        <li>Batch size: {{ task.batchsize }}</li>
+                                                        <li>Update: {{ task.update }}</li>
+                                                        <li>Only newer: {{ task.onlyNewer }}</li>
+                                                        <li>No ordering: {{ task.noOrdering }}</li>
+                                                        <li>Throttle: {{ task.throttle }}</li>
+                                                        <li>Resume from: {{ task.resumeFrom }}</li>
+
+                                                        <li ng-show="task.excludes.length > 0">
+                                                            Excludes:
+                                                            <ul>
+                                                                <li ng-repeat="exclude in task.excludes">{{exclude}}</li>
+                                                            </ul>
+                                                        </li>
+                                                    </ul>
+                                                </td>
+                                                <td class="actions">
+
+                                                    <div class="action-button">
+                                                        <a href="#" ng-click="task.expanded = !task.expanded"
+                                                           ng-class="task.expanded ? 'icon-treecollapse' : 'icon-treeexpand'"></a>
+                                                    </div>
+
+                                                    <div class="action-button">
+                                                        <a href="#" ng-show="task.status.state == 'NEW'"
+                                                           ng-click="start(task)"
+                                                           class="icon-play-circle"></a>
+                                                    </div>
+
+                                                    <div class="action-button">
+                                                        <a href="#" ng-show="task.status.state == 'RUNNING'"
+                                                           ng-click="stop(task)"
+                                                           class="icon-stop"></a>
+                                                    </div>
+
+                                                    <div class="action-button">
+                                                        <a href="#" ng-click="remove(task)"
+                                                           class="icon-delete">
+                                                        </a>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
                         </div>
                     </div>
-                </div>				
-			</div>
-		</div>
+                </div>
+            </div>
 
-	</div>
+            <cq:include script="includes/create-task-template.jsp"/>
+        </div>
 
-	<cq:includeClientLib js="vlt-rcp.app" />
-	<script type="text/ng-template" id="createTaskTemplate">
-    <h1>Create a new task</h1>
-	<form name="myForm" ng-controller="MainCtrl">
-	<table class="fullwidth">
-        <tr><td><label>Id</label></td><td><input type="text" ng-model="task_id" name="id" size="30"></td></tr>
-        <tr><td><label>Source</label></td><td class="fullwidth"><input type="text" class="fullwidth" ng-model="task_src" name="src" placeholder="http://admin:admin@localhost:4502/crx/server/-/jcr:root/content/dam/geometrixx"></td></tr>
-        <tr><td><label>Destination</label></td><td><input type="text" class="fullwidth" ng-model="task_dst" name="dst" placeholder="/content/geometrixx2"></td></tr>
-        <tr><td><label>Recursive</label></td><td><input class="opaque" type="checkbox" ng-model="checkboxModel.recursive"></td></tr>
-        <tr><td><label>Update</label></td><td><input class="opaque" type="checkbox" ng-model="checkboxModel.update"></td></tr>
-        <tr><td><label>Only&nbsp;newer</label></td><td><input class="opaque" type="checkbox" ng-model="checkboxModel.onlyNewer"></td></tr>
-        <tr><td><label>No&nbsp;ordering</label></td><td><input class="opaque" type="checkbox" ng-model="checkboxModel.noOrdering"></td></tr>
-        <tr><td><label>Resume&nbsp;from</label></td><td><input type="text" class="fullwidth" ng-model="task_resumeFrom" name="resumeFrom" placeholder="/content/geometrixx2"></td></tr>
-        <tr><td><label>Batch&nbsp;size</label></td><td><input type="text" ng-model="task_batchSize" name="resumeFrom" placeholder="2048" size="5"></td></tr>
-        <tr><td><label>Throttle</label></td><td><input type="text" ng-model="task_throttle" name="throttle" placeholder="1" size="2"></td></tr>
-        <tr><td valign="top"><label>Excludes</label></td><td align="right"><a href="#" class="icon-add small" ng-click="addExclude()"></a>
-        <div ng-show="excludes.length > 0">
-            <ul class="list-unstyled" ng-repeat="exclude in excludes">
-              <li><nobr><input type="text" class="fullwidth" ng-model="exclude.value" name="exclude{{$index}}" placeholder="/content/geometrixx/(en|fr)/tools(/.*)?"><a href="#" ng-click="removeExclude($index)" class="icon-delete"></a></nobr></li>
-			</ul>
-        </div>				
-        </td></tr>
-	    <tr><td></td><td><input type="button" value="Create" ng-click="confirm()"/><input type="button" value="Cancel" ng-click="closeThisDialog()"/></td></tr>
-	</table>
-    </form>
-	</script>
+        <cq:includeClientLib js="acs-tools.vlt-rcp.app"/>
 
-</body>
+        <%-- Register angular app; Decreases chances of collisions w other angular apps on the page (ex. via injection) --%>
+        <script type="text/javascript">
+            angular.bootstrap(document.getElementById('acs-tools-vlt-rcp-app'),
+                    ['vltRcpApp']);
+        </script>
+    </body>
 </html>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/vlt-rcp.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/vlt-rcp.jsp
@@ -47,7 +47,7 @@
                         href="${currentPage.path}.html">VLT-RCP</a>
                 </nav>
 
-                <div class="drawer theme-dark">
+                <div ng-hide="vltMissing" class="drawer theme-dark">
                     <label>Auto refresh </label><input type="checkbox" ng-model="checkboxModel.autoRefresh">
                     <a href="#" class="icon-add medium" ng-click="createTask()"></a>
                 </div>
@@ -62,12 +62,12 @@
                     <div class="content-container">
                         <div class="content-container-inner">
 
-                            <h1>VLT-RCP Web UI</h1>
+                            <h1>VLT-RCP</h1>
 
-                            <%-- VLT-RCP 3.1.6+ Not installed --%>
+                            <%-- VLT-RCP Not installed --%>
                             <div ng-show="vltMissing">
                                 <div class="alert error large">
-                                    <strong>VLT-RCP 3.1.6+ Missing or Inactive</strong>
+                                    <strong>VLT-RCP Bundle Missing or Inactive</strong>
                                     <div>
                                         VLT-RCP endpoint could not be reached.
 
@@ -77,10 +77,11 @@
                                                    target="_blank">Download and install</a>
                                                 VLT-RCP on this AEM instance.
                                             </li>
-                                            <li>Ensure the Apache Jackrabbit FileVault RCP Server Bundle is
+                                            <li>Ensure the
                                                 <a href="/system/console/bundles"
                                                    x-cq-linkchecker="skip"
-                                                   target="_blank">Active</a>.</li>
+                                                   target="_blank">Apache Jackrabbit FileVault RCP Server Bundle is
+                                                    Active</a>.</li>
                                         </ol>
                                     </div>
                                 </div>
@@ -110,7 +111,7 @@
                                     <h2>Current Tasks</h2>
 
                                     <p>
-                                        Click on the <i class="icon-play-circle"></i> to view the details for each Task.
+                                        Click on the <i class="icon-treeexpand"></i> to view the details for each Task.
                                     </p>
 
                                     <table class="data tasks">

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/vlt-rcp.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/vlt-rcp.jsp
@@ -67,7 +67,7 @@
                             <%-- VLT-RCP Not installed --%>
                             <div ng-show="vltMissing">
                                 <div class="alert error large">
-                                    <strong>VLT-RCP Bundle Missing or Inactive</strong>
+                                    <strong>VLT-RCP servlet missing, inactive or unreachable</strong>
                                     <div>
                                         VLT-RCP endpoint could not be reached.
 
@@ -77,11 +77,16 @@
                                                    target="_blank">Download and install</a>
                                                 VLT-RCP on this AEM instance.
                                             </li>
-                                            <li>Ensure the
-                                                <a href="/system/console/bundles"
-                                                   x-cq-linkchecker="skip"
-                                                   target="_blank">Apache Jackrabbit FileVault RCP Server Bundle is
-                                                    Active</a>.</li>
+                                            <li>Ensure the  <a href="/system/console/bundles"  x-cq-linkchecker="skip"
+                                                               target="_blank">Apache Jackrabbit FileVault RCP Server
+                                                Bundle is Active</a>.
+                                            </li>
+                                            <li>
+                                                The VLT-RCP endpoint URL must be accessible and not blocked via
+                                                Dispatcher or another reverse proxy. Note: The VLT RCP servlet
+                                                endpoint changed from &quot;/system/jackrabbit/filevault/rcp&quot; to
+                                                &quot;/libs/granite/packaging/rcp&quot; in VLT-RCP 3.1.6.
+                                            </li>
                                         </ol>
                                     </div>
                                 </div>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/vlt-rcp.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/vlt-rcp.jsp
@@ -141,8 +141,9 @@
                                                     <div ng-show="task.expanded">
 
                                                         <ul>
-                                                            <li>Current path: {{ task.status.currentPath }}</li>
-                                                            <li>Last saved path: {{ task.status.lastSavedPath }}</li>
+                                                            <li>Current path: {{ task.status.currentPath || 'N/A' }}</li>
+                                                            <li>Last saved path:
+                                                                {{ task.status.lastSavedPath || 'N/A' }}</li>
                                                             <li>Total nodes: {{ task.status.totalNodes }}</li>
                                                             <li>Total size: {{ task.status.totalSize }}</li>
                                                             <li>Current size: {{ task.status.currentSize }}</li>
@@ -162,8 +163,8 @@
                                                         <li>Update: {{ task.update }}</li>
                                                         <li>Only newer: {{ task.onlyNewer }}</li>
                                                         <li>No ordering: {{ task.noOrdering }}</li>
-                                                        <li>Throttle: {{ task.throttle }}</li>
-                                                        <li>Resume from: {{ task.resumeFrom }}</li>
+                                                        <li>Throttle: {{ task.throttle || 0}} seconds</li>
+                                                        <li>Resume from: {{ task.resumeFrom || 'Not set'}}</li>
 
                                                         <li ng-show="task.excludes.length > 0">
                                                             Excludes:


### PR DESCRIPTION
Aligned the visual aesthetic a little more closely to the rest of ACS Tools.

Added a check during init() so this tool auto-detects the version of VLT-RCP (it checks the URIs) and uses the one that returns a 200.

(Note the Play icon is not the Treeexpand + icon in the instruction message; fixed after screenshot was taken)
![vlt-rcp___acs_aem_tools](https://cloud.githubusercontent.com/assets/1451868/7338149/ef793d26-ec10-11e4-9f93-9e55c51aca44.png)

![vlt-rcp___acs_aem_tools](https://cloud.githubusercontent.com/assets/1451868/7338153/1c653600-ec11-11e4-9770-c679b7451c5f.png)

Friendly message if VLT is not installed or disabled...

![vlt-rcp___acs_aem_tools](https://cloud.githubusercontent.com/assets/1451868/7338166/8c420b60-ec11-11e4-9846-b6fe001159c5.png)


