### PR TITLE
Tracer - Enable logs for specific category at specific level and  only for specific request!

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/tools/tracer/impl/LogTracer.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/tracer/impl/LogTracer.java
@@ -1,0 +1,607 @@
+/*
+ * #%L
+ * ACS AEM Tools Bundle
+ * %%
+ * Copyright (C) 2014 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.tools.tracer.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.helpers.CyclicBuffer;
+import ch.qos.logback.core.spi.FilterReply;
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.ConfigurationPolicy;
+import org.apache.felix.scr.annotations.Deactivate;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.PropertyUnbounded;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.request.RequestProgressTracker;
+import org.apache.sling.commons.osgi.ManifestHeader;
+import org.apache.sling.commons.osgi.PropertiesUtil;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceRegistration;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.helpers.MessageFormatter;
+
+/**
+ * Tracer provides support for enabling the logs for specific category at specific level and
+ * only for specific request. It provides a very fine level of control via config provided
+ * as part of HTTP request around how the logging should be performed for given category.
+ *
+ * This is specially useful for those parts of the system which are involved in every request.
+ * For such parts enabling the log at global level would flood the logs and create lots of noise.
+ * Using Tracer one can enable log for that request which is required to be probed
+ */
+@Component(
+        label = "ACS AEM Tools - Log Tracer",
+        description = "Provides support for enabling log for specific loggers on per request basis",
+        policy = ConfigurationPolicy.REQUIRE,
+        metatype = true
+)
+public class LogTracer {
+    /**
+     * Request parameter name having comma separated value to determine list of tracers to
+     * enable
+     */
+    public static final String PARAM_TRACER = "tracers";
+
+    /**
+     * Request param used to determine tracer config as part of request itself. Like
+     *
+     * org.apache.sling;level=trace,org.apache.jackrabbit
+     */
+    public static final String PARAM_TRACER_CONFIG = "tracerConfig";
+
+    public static final String HEADER_TRACER_CONFIG = "X-AEM-Tracer-Config";
+
+    public static final String HEADER_TRACER = "X-AEM-Tracers";
+
+
+    private static final String QUERY_LOGGER = "org.apache.jackrabbit.oak.query.QueryEngineImpl";
+
+    /**
+     * Following queries are internal to Oak and are fired for login/access control
+     * etc. They should be ignored. With Oak 1.2+ such queries are logged at trace
+     * level (OAK-2304)
+     */
+    private static final String[] IGNORABLE_QUERIES = {
+            "SELECT * FROM [nt:base] WHERE [jcr:uuid] = $id",
+            "SELECT * FROM [nt:base] WHERE PROPERTY([rep:members], 'WeakReference') = $uuid",
+            "SELECT * FROM [rep:Authorizable]WHERE [rep:principalName] = $principalName",
+    };
+
+    @Property(label = "Tracer Sets",
+            description = "Default list of tracer sets configured. Tracer Set config confirms " +
+                    "to following format. <set name> : <logger name>;level=<level name>, other loggers",
+            unbounded = PropertyUnbounded.ARRAY,
+            value = {
+                    "oak-query : org.apache.jackrabbit.oak.query.QueryEngineImpl;level=debug",
+                    "oak-writes : org.apache.jackrabbit.oak.jcr.operations.writes;level=trace"
+            }
+    )
+    private static final String PROP_TRACER_SETS = "tracerSets";
+
+    private static final boolean PROP_TRACER_ENABLED_DEFAULT = true;
+    @Property(label = "Enabled",
+            description = "Enable the Tracer",
+            boolValue = PROP_TRACER_ENABLED_DEFAULT
+    )
+    private static final String PROP_TRACER_ENABLED = "enabled";
+
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(LogTracer.class);
+
+    private final Map<String, TracerSet> tracers = new HashMap<String, TracerSet>();
+
+    private BundleContext bundleContext;
+
+    private ServiceRegistration slingFilterRegistration;
+
+    private ServiceRegistration filterRegistration;
+
+    private final AtomicReference<ServiceRegistration> logCollectorReg
+            = new AtomicReference<ServiceRegistration>();
+
+    private final AtomicInteger logCollectorRegCount = new AtomicInteger();
+
+    private final ThreadLocal<TracerContext> requestContextHolder = new ThreadLocal<TracerContext>();
+
+    @Activate
+    private void activate(Map<String, ?> config, BundleContext context) {
+        this.bundleContext = context;
+        initializeTracerSet(config);
+        boolean enabled = PropertiesUtil.toBoolean(config.get(PROP_TRACER_ENABLED), PROP_TRACER_ENABLED_DEFAULT);
+        if (enabled) {
+            registerFilters(context);
+            LOG.info("Log tracer enabled. Required filters registered");
+        }
+    }
+
+    @Deactivate
+    private void deactivate() {
+        if (slingFilterRegistration != null) {
+            slingFilterRegistration.unregister();
+            slingFilterRegistration = null;
+        }
+
+        if (filterRegistration != null) {
+            filterRegistration.unregister();
+            filterRegistration = null;
+        }
+
+        ServiceRegistration reg = logCollectorReg.getAndSet(null);
+        if (reg != null) {
+            reg.unregister();
+        }
+
+        requestContextHolder.remove();
+    }
+
+    TracerContext getTracerContext(String tracerSetNames, String tracerConfig) {
+        //No config or tracer set name provided. So tracing not required
+        if (tracerSetNames == null && tracerConfig == null) {
+            return null;
+        }
+
+        List<TracerConfig> configs = new ArrayList<TracerConfig>();
+
+        List<String> invalidNames = new ArrayList<String>();
+        if (tracerSetNames != null) {
+            for (String tracerSetName : tracerSetNames.split(",")) {
+                TracerSet ts = tracers.get(tracerSetName.toLowerCase(Locale.ENGLISH));
+                if (ts != null) {
+                    configs.addAll(ts.configs);
+                } else {
+                    invalidNames.add(tracerSetName);
+                }
+            }
+        }
+
+        if (!invalidNames.isEmpty()) {
+            LOG.warn("Invalid tracer set names passed [{}] as part of [{}]", invalidNames, tracerSetNames);
+        }
+
+        if (tracerConfig != null) {
+            TracerSet ts = new TracerSet("custom", tracerConfig);
+            configs.addAll(ts.configs);
+        }
+
+        return new TracerContext(configs.toArray(new TracerConfig[configs.size()]));
+    }
+
+    Map<String, TracerSet> getTracers() {
+        return Collections.unmodifiableMap(tracers);
+    }
+
+    private void initializeTracerSet(Map<String, ?> config) {
+        String[] tracerSetConfigs = PropertiesUtil.toStringArray(config.get(PROP_TRACER_SETS), new String[0]);
+
+        for (String tracerSetConfig : tracerSetConfigs) {
+            TracerSet tc = new TracerSet(tracerSetConfig);
+            tracers.put(tc.name, tc);
+        }
+    }
+
+    private void registerFilters(BundleContext context) {
+        Properties slingFilterProps = new Properties();
+        slingFilterProps.setProperty("filter.scope", "REQUEST");
+        slingFilterProps.setProperty(Constants.SERVICE_DESCRIPTION, "Sling Filter required for Log Tracer");
+        slingFilterRegistration = context.registerService(Filter.class.getName(),
+                new SlingTracerFilter(), slingFilterProps);
+
+        Properties filterProps = new Properties();
+        filterProps.setProperty("pattern", "/.*");
+        filterProps.setProperty(Constants.SERVICE_DESCRIPTION, "Servlet Filter required for Log Tracer");
+        filterRegistration = context.registerService(Filter.class.getName(),
+                new TracerFilter(), filterProps);
+    }
+
+    /**
+     * TurboFilters causes slowness as they are executed on critical path
+     * Hence care is taken to only register the filter only when required
+     * Logic below ensures that filter is only registered for the duration
+     * or request which needs to be "monitored".
+     * <p/>
+     * If multiple such request are performed then also only one filter gets
+     * registered
+     */
+    private void registerLogCollector() {
+        synchronized (logCollectorRegCount) {
+            int count = logCollectorRegCount.getAndIncrement();
+            if (count == 0) {
+                ServiceRegistration reg = bundleContext.registerService(TurboFilter.class.getName(),
+                        new LogCollector(), null);
+                logCollectorReg.set(reg);
+            }
+        }
+    }
+
+    private void unregisterLogCollector() {
+        synchronized (logCollectorRegCount) {
+            int count = logCollectorRegCount.decrementAndGet();
+            if (count == 0) {
+                ServiceRegistration reg = logCollectorReg.getAndSet(null);
+                reg.unregister();
+            }
+        }
+    }
+
+    private abstract class AbstractFilter implements Filter {
+        @Override
+        public void init(FilterConfig filterConfig) throws ServletException {
+        }
+
+        @Override
+        public void destroy() {
+
+        }
+
+        protected void enableCollector(TracerContext tracerContext) {
+            requestContextHolder.set(tracerContext);
+            registerLogCollector();
+        }
+
+        protected void disableCollector() {
+            requestContextHolder.remove();
+            unregisterLogCollector();
+        }
+    }
+
+    /**
+     * Filter which registers at root and check for Tracer related params. If found to
+     * be enabled then perform required setup for the logs to be captured.
+     */
+    private class TracerFilter extends AbstractFilter {
+
+        @Override
+        public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
+                             FilterChain filterChain) throws IOException, ServletException {
+
+            //At generic filter level we just check for tracer hint via Header (later Cookie)
+            //and not touch the request parameter to avoid eager initialization of request
+            //parameter map
+
+            HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
+            TracerContext tracerContext = getTracerContext(httpRequest.getHeader(HEADER_TRACER),
+                    httpRequest.getHeader(HEADER_TRACER_CONFIG));
+            try {
+                if (tracerContext != null) {
+                    enableCollector(tracerContext);
+                }
+                filterChain.doFilter(servletRequest, servletResponse);
+            } finally {
+                if (tracerContext != null) {
+                    disableCollector();
+                }
+            }
+        }
+
+
+    }
+
+    /**
+     * Sling level filter to extract the RequestProgressTracker and passes that to current
+     * thread's TracerContent
+     */
+    private class SlingTracerFilter extends AbstractFilter {
+        @Override
+        public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
+                             FilterChain filterChain) throws IOException, ServletException {
+            SlingHttpServletRequest slingRequest = (SlingHttpServletRequest) servletRequest;
+            TracerContext tracerContext = requestContextHolder.get();
+
+            boolean createdContext = false;
+
+            //Check if the global filter created context based on HTTP headers. If not
+            //then check from request params
+            if (tracerContext == null) {
+                tracerContext = getTracerContext(slingRequest.getParameter(PARAM_TRACER),
+                        slingRequest.getParameter(PARAM_TRACER_CONFIG));
+                if (tracerContext != null) {
+                    createdContext = true;
+                }
+            }
+
+            try {
+                if (tracerContext != null) {
+                    tracerContext.registerProgressTracker(slingRequest.getRequestProgressTracker());
+
+                    //if context created in this filter then enable the collector
+                    if (createdContext) {
+                        enableCollector(tracerContext);
+                    }
+                }
+                filterChain.doFilter(servletRequest, servletResponse);
+            } finally {
+                if (tracerContext != null) {
+                    tracerContext.done();
+
+                    if (createdContext) {
+                        disableCollector();
+                    }
+                }
+            }
+        }
+    }
+
+    private class LogCollector extends TurboFilter {
+
+        @Override
+        public FilterReply decide(Marker marker, Logger logger, Level level,
+                                  String format, Object[] params, Throwable t) {
+            TracerContext tracer = requestContextHolder.get();
+            if (tracer == null) {
+                return FilterReply.NEUTRAL;
+            }
+
+            if (tracer.shouldLog(logger.getName(), level)) {
+                if (format == null) {
+                    return FilterReply.ACCEPT;
+                }
+                if (tracer.log(logger.getName(), format, params)) {
+                    return FilterReply.ACCEPT;
+                }
+            }
+
+            return FilterReply.NEUTRAL;
+        }
+    }
+
+    static class TracerContext {
+        private static final int LOG_BUFFER_SIZE = 50;
+        /*
+         * In memory buffer to store logs till RequestProgressTracker is registered.
+         * This would be required for those case where TracerContext is created at
+         * normal Filter level which gets invoked before Sling layer is hit.
+         *
+         * Later when Sling layer is hit and SlingTracerFilter is invoked
+         * then it would register the RequestProgressTracker and then these inmemory logs
+         * would be dumped there
+         */
+        private CyclicBuffer<String> buffer;
+        private RequestProgressTracker progressTracker;
+        int queryCount;
+        final TracerConfig[] tracers;
+
+        public TracerContext(TracerConfig[] tracers) {
+            this.tracers = tracers;
+
+            //Say if the list is like com.foo;level=trace,com.foo.bar;level=info.
+            // Then first config would result in a match and later config would
+            // not be able to suppress the logs from a child category
+            //To handle such cases we sort the config. With having more depth i.e. more specific
+            //coming first and others later
+            Arrays.sort(tracers);
+        }
+
+        public boolean shouldLog(String logger, Level level) {
+            for (TracerConfig tc : tracers) {
+                MatchResult mr = tc.match(logger, level);
+                if (mr == MatchResult.MATCH_LOG) {
+                    return true;
+                } else if (mr == MatchResult.MATCH_NO_LOG) {
+                    return false;
+                }
+            }
+            return false;
+        }
+
+        public boolean log(String logger, String format, Object[] params) {
+            if (QUERY_LOGGER.equals(logger)
+                    && params != null && params.length == 2) {
+                return logQuery((String) params[1]);
+            }
+            return logWithLoggerName(logger, format, params);
+        }
+
+        public void done() {
+            if (queryCount > 0) {
+                progressTracker.log("JCR Query Count {0}", queryCount);
+            }
+        }
+
+        /**
+         * Registers the progress tracker and also logs all the in memory logs
+         * collected so far to the tracker
+         */
+        public void registerProgressTracker(RequestProgressTracker requestProgressTracker) {
+            this.progressTracker = requestProgressTracker;
+            if (buffer != null) {
+                for (String msg : buffer.asList()) {
+                    progressTracker.log(msg);
+                }
+                buffer = null;
+            }
+        }
+
+        private boolean logWithLoggerName(String loggerName, String format, Object... params) {
+            String msg = MessageFormatter.arrayFormat(format, params).getMessage();
+            msg = "[" + loggerName + "] " + msg;
+            if (progressTracker == null) {
+                if (buffer == null) {
+                    buffer = new CyclicBuffer<String>(LOG_BUFFER_SIZE);
+                }
+                buffer.add(msg);
+            } else {
+                progressTracker.log(msg);
+            }
+            return true;
+        }
+
+        private boolean logQuery(String query) {
+            if (ignorableQuery(query)) {
+                return false;
+            }
+            queryCount++;
+            logWithLoggerName("JCR", " Query {}", query);
+            return true;
+        }
+
+        private boolean ignorableQuery(String msg) {
+            for (String ignorableQuery : IGNORABLE_QUERIES) {
+                if (msg.contains(ignorableQuery)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    static class TracerSet {
+        public static final String LEVEL = "level";
+        final String name;
+        final List<TracerConfig> configs;
+
+        public TracerSet(String config) {
+            int indexOfColon = config.indexOf(':');
+            if (indexOfColon == -1) {
+                throw new IllegalArgumentException("Invalid tracer config format. TracerSet " +
+                        "name cannot be determined " + config);
+            }
+
+            name = config.substring(0, indexOfColon).toLowerCase().trim();
+            configs = parseTracerConfigs(config.substring(indexOfColon + 1));
+        }
+
+        public TracerSet(String name, String config) {
+            this.name = name;
+            this.configs = parseTracerConfigs(config);
+        }
+
+        public TracerConfig getConfig(String category) {
+            for (TracerConfig tc : configs) {
+                if (tc.match(category)) {
+                    return tc;
+                }
+            }
+            return null;
+        }
+
+        private static List<TracerConfig> parseTracerConfigs(String config) {
+            ManifestHeader parsedConfig = ManifestHeader.parse(config);
+            List<TracerConfig> result = new ArrayList<TracerConfig>(parsedConfig.getEntries().length);
+            for (ManifestHeader.Entry e : parsedConfig.getEntries()) {
+                String category = e.getValue();
+
+                //Defaults to Debug
+                Level level = Level.valueOf(e.getAttributeValue(LEVEL));
+                result.add(new TracerConfig(category, level));
+            }
+            return Collections.unmodifiableList(result);
+        }
+    }
+
+    static class TracerConfig implements Comparable<TracerConfig> {
+        final String loggerName;
+        final Level level;
+        final int depth;
+
+        public TracerConfig(String loggerName, Level level) {
+            this.loggerName = loggerName;
+            this.level = level;
+            this.depth = getDepth(loggerName);
+        }
+
+        public boolean match(String loggerName) {
+            if (loggerName.startsWith(this.loggerName)) {
+                return true;
+            }
+            return false;
+        }
+
+        public MatchResult match(String loggerName, Level level) {
+            if (loggerName.startsWith(this.loggerName)) {
+                if (level.isGreaterOrEqual(this.level)) {
+                    return MatchResult.MATCH_LOG;
+                }
+                return MatchResult.MATCH_NO_LOG;
+            }
+            return MatchResult.NO_MATCH;
+        }
+
+        @Override
+        public int compareTo(TracerConfig o) {
+            int comp = depth > o.depth ? -1 : depth < o.depth ? 1 : 0;
+            if (comp == 0) {
+                comp = loggerName.compareTo(o.loggerName);
+            }
+            return comp;
+        }
+
+        private static int getDepth(String loggerName) {
+            int depth = 0;
+            int fromIndex = 0;
+            while (true) {
+                int index = getSeparatorIndexOf(loggerName, fromIndex);
+                depth++;
+                if (index == -1) {
+                    break;
+                }
+                fromIndex = index + 1;
+            }
+            return depth;
+        }
+
+        /*
+         * Taken from LoggerNameUtil. Though its accessible Logback is might not maintain
+         * strict backward compatibility for such util classes. So copy the logic
+         */
+        private static int getSeparatorIndexOf(String name, int fromIndex) {
+            int i = name.indexOf(CoreConstants.DOT, fromIndex);
+            if (i != -1) {
+                return i;
+            } else {
+                return name.indexOf(CoreConstants.DOLLAR, fromIndex);
+            }
+        }
+    }
+
+    enum MatchResult {
+        MATCH_LOG,
+        /**
+         * Logger category matched but level not. So logging should
+         * not be performed and no further TracerConfig should be matched for this
+         */
+        MATCH_NO_LOG,
+
+        NO_MATCH
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/tools/tracer/impl/LogTracerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/tools/tracer/impl/LogTracerTest.java
@@ -1,0 +1,96 @@
+/*
+ * #%L
+ * ACS AEM Tools Bundle
+ * %%
+ * Copyright (C) 2014 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.tools.tracer.impl;
+
+import java.util.Arrays;
+
+import ch.qos.logback.classic.Level;
+import com.adobe.acs.tools.tracer.impl.LogTracer.TracerConfig;
+import com.adobe.acs.tools.tracer.impl.LogTracer.TracerContext;
+import com.adobe.acs.tools.tracer.impl.LogTracer.TracerSet;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class LogTracerTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseInvalidConfig() throws Exception {
+        new TracerSet("foo");
+    }
+
+    @Test
+    public void parseTracerSet() throws Exception {
+        TracerSet a = new TracerSet("foo : com.foo, com.bar;level=INFO");
+        assertEquals("foo", a.name);
+        TracerConfig tcfoo = a.getConfig("com.foo");
+        assertNotNull(tcfoo);
+        assertEquals(Level.DEBUG, tcfoo.level);
+
+        assertNotNull("Config for parent should match for child", a.getConfig("com.foo.bar"));
+
+
+        TracerConfig tcbar = a.getConfig("com.bar");
+        assertNotNull(tcbar);
+        assertEquals(Level.INFO, tcbar.level);
+    }
+
+    @Test
+    public void childLoggerLevelDiff() throws Exception{
+        TracerSet ts = new TracerSet("foo : a.b;level=trace, a.b.c;level=info");
+        TracerContext tc = getContext(ts);
+
+        assertTrue(tc.shouldLog("a.b", Level.TRACE));
+        assertTrue(tc.shouldLog("a.b.d", Level.TRACE));
+        assertFalse(tc.shouldLog("a.b.c", Level.TRACE));
+    }
+
+    @Test
+    public void tracerConfigTest() throws Exception{
+        TracerConfig tc = new TracerConfig("a.b.c", Level.DEBUG);
+        assertEquals(3, tc.depth);
+        assertEquals(LogTracer.MatchResult.MATCH_LOG, tc.match("a.b.c.d", Level.DEBUG));
+        assertEquals(LogTracer.MatchResult.MATCH_NO_LOG, tc.match("a.b.c.d", Level.TRACE));
+        assertEquals(LogTracer.MatchResult.NO_MATCH, tc.match("a.b.d", Level.TRACE));
+    }
+
+    @Test
+    public void tracerConfigSort() throws Exception{
+        TracerConfig[] configs = new TracerConfig[] {
+          new TracerConfig("a.b.c.d", Level.DEBUG),
+          new TracerConfig("a", Level.DEBUG),
+          new TracerConfig("a.b.e", Level.DEBUG),
+        };
+
+        Arrays.sort(configs);
+        assertEquals("a.b.c.d", configs[0].loggerName);
+        assertEquals("a.b.e", configs[1].loggerName);
+        assertEquals("a", configs[2].loggerName);
+
+    }
+
+    private static TracerContext getContext(TracerSet ts){
+        return new TracerContext(ts.configs.toArray(new TracerConfig[ts.configs.size()]));
+    }
+
+}


### PR DESCRIPTION
Tracer provides support for enabling the logs for specific category at specific level and
only for specific request. It provides a very fine level of control via config provided
as part of HTTP request around how the logging should be performed for given category.

This is specially useful for those parts of the system which are involved in every request.
For such parts enabling the log at global level would flood the logs and create lots of noise.
Using Tracer one can enable log for that request which is required to be probed.

For e.g. determining what nodes are written for a given POST request can be simply done by including an extra request parameters.

```
curl -D - -u admin:admin \
 -d "./jcr:content/jcr:title=Summer Collection" \
 -d ":name=summer-collection" \
 -d "./jcr:primaryType=sling:Folder" \
 -d "./jcr:content/jcr:primaryType=nt:unstructured" \
 -d "tracers=oak-writes" \
 http://localhost:4502/content/dam/
```

Configuration
===========

![tracer-config](https://cloud.githubusercontent.com/assets/664531/7563713/2dd207cc-f7fd-11e4-93c9-56276fb8a658.png)

**Note that by default Tracer would not be enabled and you would need to save the OSGi config to get it activated**

Tracer support two ways to enable logging.

Tracer Sets
---------------

Tracer sets are collection of predefined logging categories matching specific area of an application. These can for now be configured as part of OSGi config

```
oak-query : org.apache.jackrabbit.oak.query.QueryEngineImpl;level=debug
auth : org.apache.sling.auth;level=trace,org.apache.jackrabbit.oak.security
```
The config is of following format

`< set name > : <tracer config>`

Where the config is of following format

```
tracerConfig := loggerConfig ( ',' loggerConfig) *
loggerConfig := loggerName (; attributes)*
attributes := attributeName '=' attributeValue
```

Currently following attributes are support
* `level` - Either of TRACE, DEBUG, INFO, WARN, ERROR

Performance Impact
--------------------------

Tracer makes use of [Logback TuboFilter][1] to intercept the logging calls and only enable them for those which are enabled via tracer config for the request. The filter is only registered for the duration of that request hence would avoid adding the cost for normal run.

You can also disable the Tracer completely via OSGi config.

Where do logs go
==============

The logs captured are logged at two places

RequestProgressTracker
--------------------------------

Sling provides support for recording recent requests which can be accessed via [Recent Requests Plugin][2]. It would list down the list of recent request and then on clicking them you can see the logs showed on the UI.

The logging there is done via [RequestProgressTracker][3] ([intro][4]). By default recent request plugin gets overflown as it captures request even for css, js files. To avoid that you can modify the config as part of _Sling Main Servlet_ config

![sling-main-servlet-config](https://cloud.githubusercontent.com/assets/664531/7564216/16c20c62-f802-11e4-929b-963a28f16afd.png).

Using a regex like ```^.*\.(?!jpg$|png$|js$|css$|woff$)[^.]+$``` would avoid noise

With that you can see log entries like below at http://localhost:4502/system/console/requests?index=xxx

```
132 (2015-05-11 17:39:55) LOG [JCR]  Query SELECT * FROM [granite:InboxItem] AS s where  status='ACTIVE' ORDER BY s.startTime DESC
134 (2015-05-11 17:39:55) TIMER_END{53,/libs/cq/gui/components/endor/badge/badge.jsp#18}
...
1316 (2015-05-11 17:39:56) LOG JCR Query Count 3
1320 (2015-05-11 17:39:56) TIMER_END{1320,Request Processing} Request Processing
```

Server Logs
---------------

Further the logs also go to normal server side logs. By default they would go to the error.log. If you have routed the logs of specific categories to different files then normal Logback logging rules would apply

Usage
=====

Tracing can be done in various ways for a given HTTP request. Tracer looks for following hints as part of request

* Tracer set names - Comma separated list of tracer set names which need to be enabled. e.g. `oak-query, oak-writes` etc
* tracerConfig - Raw tracing config only used for that specific request

Request Parameters
--------------------------

Param names
* `tracers`  - Tracer set names
* `tracerConfig` - Tracer config like org.apache.sling.auth;level=trace`

```
curl -u admin:admin http://localhost:4802/projects.html?tracerConfig=org.apache.sling
```

Above request would turn on debug level logging (default level for tracer) for `org.apache.sling` category.

```
curl -D - -u admin:admin \
 -d "./jcr:content/jcr:title=Summer Collection" \
 -d ":name=summer-collection" \
 -d "./jcr:primaryType=sling:Folder" \
 -d "./jcr:content/jcr:primaryType=nt:unstructured" \
 -d "tracers=oak-writes" \
 http://localhost:4502/content/dam/
```

Above request would create a folder in Assets and for that we have enabled the `oak-writes` tracer. This would result in following output 

```
2015-05-11 17:30:42,840 INFO  admin [127.0.0.1 [1431345642836] POST /content/dam/ HTTP/1.1] c.a.acs.acs-aem-tools-bundle - Service [4858] ServiceEvent REGISTERED 
2015-05-11 17:30:42,846 TRACE admin [127.0.0.1 [1431345642836] POST /content/dam/ HTTP/1.1] o.a.j.o.jcr.operations.writes session-12895- [session-12895] Adding node [/content/dam/summer-collection] 
2015-05-11 17:30:42,849 TRACE admin [127.0.0.1 [1431345642836] POST /content/dam/ HTTP/1.1] o.a.j.o.jcr.operations.writes session-12895- [session-12895] setPrimaryType 
2015-05-11 17:30:42,849 TRACE admin [127.0.0.1 [1431345642836] POST /content/dam/ HTTP/1.1] o.a.j.o.jcr.operations.writes session-12895- [session-12895] Adding node [/content/dam/summer-collection/jcr:content] 
2015-05-11 17:30:42,849 TRACE admin [127.0.0.1 [1431345642836] POST /content/dam/ HTTP/1.1] o.a.j.o.jcr.operations.writes session-12895- [session-12895] Setting property [/content/dam/summer-collection/jcr:content/jcr:title] 
2015-05-11 17:30:42,850 TRACE admin [127.0.0.1 [1431345642836] POST /content/dam/ HTTP/1.1] o.a.j.o.jcr.operations.writes session-12895- [session-12895] setPrimaryType 
2015-05-11 17:30:42,850 TRACE admin [127.0.0.1 [1431345642836] POST /content/dam/ HTTP/1.1] o.a.j.o.jcr.operations.writes session-12895- [session-12895] setPrimaryType 
2015-05-11 17:30:42,856 TRACE admin [127.0.0.1 [1431345642836] POST /content/dam/ HTTP/1.1] o.a.j.o.jcr.operations.writes session-12895- [session-12895] save 
```

Request Headers
-----------------------

Some request like initial authentication processing does not involve Sling MainServlet and hence for those request logging cannot be done to RequestProgressTracker. Instead we can just get logs enabled and route them to normal logging on server side. For that you need to use HTTP header

* `X-AEM-Tracers` - Set of tracer set names
* `X-AEM-Tracer-Config` - Tracer config

So to enable authentication related logging following request can be sent

```
curl -D - -d "j_username=admin" \
    -d "j_password=admin" \
    -d "j_validate=true"  \
    -H "X-AEM-Tracer-Config : org.apache.sling.auth;level=trace,com.day.crx.security.token;level=trace,com.day.cq.auth;level=trace,org.apache.jackrabbit.oak.security;level=trace" \
    http://localhost:4502/libs/granite/core/content/login.html/j_security_check
```

This would result in following server side logs

```
2015-05-11 17:34:56,531 INFO  NA [qtp1395423247-193] c.a.acs.acs-aem-tools-bundle - Service [4859] ServiceEvent REGISTERED 
2015-05-11 17:34:56,532 DEBUG NA [qtp1395423247-193] o.a.s.a.c.i.SlingAuthenticator - doHandleSecurity: Trying to get a session for null 
2015-05-11 17:34:56,532 DEBUG NA [qtp1395423247-193] o.a.j.o.s.a.LoginContextProviderImpl - Found pre-authenticated subject: No further login actions required. 
2015-05-11 17:34:56,532 DEBUG NA [qtp1395423247-193] o.a.j.o.s.a.LoginContextProviderImpl - Found pre-authenticated subject: No further login actions required. 
2015-05-11 17:34:56,548 DEBUG NA [qtp1395423247-193] o.a.j.o.s.a.u.LoginModuleImpl - Adding Credentials to shared state. 
2015-05-11 17:34:56,548 DEBUG NA [qtp1395423247-193] o.a.j.o.s.a.u.LoginModuleImpl - Adding login name to shared state. 
```

So _let there be light!_ :)

[1]: http://logback.qos.ch/manual/filters.html#TurboFilter
[2]: https://sling.apache.org/documentation/development/monitoring-requests.html
[3]: https://sling.apache.org/apidocs/sling5/org/apache/sling/api/request/RequestProgressTracker.html
[4]: http://dev.day.com/content/ddc/blog/2008/06/requestprogresstracker.html