### PR TITLE
Minor Fixes - Removing cq:template property that points to a non existing template & some typos

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/tools/clientlib_optimizer/impl/ClientLibOptimizerServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/clientlib_optimizer/impl/ClientLibOptimizerServlet.java
@@ -28,7 +28,7 @@ import com.day.cq.widget.HtmlLibraryManager;
 import com.day.cq.widget.LibraryType;
 
 @SlingServlet(
-        label = "ACS AEM Tools - ClientLibrary Optimizer Servlett",
+        label = "ACS AEM Tools - ClientLibrary Optimizer Servlet",
         description = "...",
         methods = { "GET" },
         resourceTypes = { "acs-tools/components/clientlibs-optimizer" },

--- a/content/src/main/content/jcr_root/etc/acs-tools/aem-fiddle/.content.xml
+++ b/content/src/main/content/jcr_root/etc/acs-tools/aem-fiddle/.content.xml
@@ -4,7 +4,6 @@
     <jcr:content
         cq:lastModified="{Date}2013-11-26T11:28:23.253-05:00"
         cq:lastModifiedBy="admin"
-        cq:template="/apps/acs-tools/templates/aemfiddle"
         jcr:primaryType="cq:PageContent"
         jcr:title="AEM Fiddle"
         sling:resourceType="acs-tools/components/aemfiddle"/>


### PR DESCRIPTION
Removing "cq:template" property which refers to a template that does not exist.