### PR TITLE
adding support in AEM Fiddle for executing Workflow process scripts

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -258,6 +258,18 @@
             <version>2.1.4</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.adobe.granite</groupId>
+            <artifactId>com.adobe.granite.workflow.api</artifactId>
+            <version>1.0.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.scripting.core</artifactId>
+            <version>2.0.28</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/ResponseLogger.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/ResponseLogger.java
@@ -1,0 +1,218 @@
+/*
+ * #%L
+ * ACS AEM Tools Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.tools.fiddle.impl;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.helpers.MarkerIgnoringBase;
+import org.slf4j.helpers.MessageFormatter;
+
+public final class ResponseLogger extends MarkerIgnoringBase implements Logger {
+
+    private static final String TRACE = "[TRACE]";
+    private static final String DEBUG = "[DEBUG]";
+    private static final String ERROR = "[ERROR]";
+    private static final String WARN = "[WARN]";
+    private static final String INFO = "[INFO]";
+    
+    private final PrintWriter writer;
+
+    public ResponseLogger(SlingHttpServletResponse response) throws IOException {
+        this.writer = response.getWriter();
+        this.name = "response";
+    }
+
+    
+
+    @Override
+    public void debug(String msg) {
+        log(DEBUG, msg);
+    }
+
+    @Override
+    public void debug(String format, Object arg) {
+        log(DEBUG, format, arg);
+    }
+
+    @Override
+    public void debug(String format, Object arg1, Object arg2) {
+        log(DEBUG, format, arg1, arg2);
+    }
+
+    @Override
+    public void debug(String format, Object[] argArray) {
+        log(DEBUG, format, argArray);
+    }
+
+    @Override
+    public void debug(String msg, Throwable t) {
+        log(DEBUG, msg, t);
+    }
+
+    
+
+    @Override
+    public void error(String msg) {
+        log(ERROR, msg);
+    }
+
+    @Override
+    public void error(String format, Object arg) {
+        log(ERROR, format, arg);
+    }
+
+    @Override
+    public void error(String format, Object arg1, Object arg2) {
+        log(ERROR, format, arg1, arg2);
+    }
+
+    @Override
+    public void error(String format, Object[] argArray) {
+        log(ERROR, format, argArray);
+    }
+
+    @Override
+    public void error(String msg, Throwable t) {
+        log(ERROR, msg, t);
+    }
+    @Override
+    public void info(String msg) {
+        log(INFO, msg);
+    }
+
+    @Override
+    public void info(String format, Object arg) {
+        log(INFO, format, arg);
+    }
+
+    @Override
+    public void info(String format, Object arg1, Object arg2) {
+        log(INFO, format, arg1, arg2);
+    }
+
+    @Override
+    public void info(String format, Object[] argArray) {
+        log(INFO, format, argArray);
+    }
+
+    @Override
+    public void info(String msg, Throwable t) {
+        log(INFO, msg, t);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return true;
+    }
+
+    @Override
+    public void trace(String msg) {
+        log(TRACE, msg);
+    }
+
+    @Override
+    public void trace(String format, Object arg) {
+        log(TRACE, format, arg);
+    }
+
+    @Override
+    public void trace(String format, Object arg1, Object arg2) {
+        log(TRACE, format, arg1, arg2);
+    }
+
+    @Override
+    public void trace(String format, Object[] argArray) {
+        log(TRACE, format, argArray);
+    }
+
+    @Override
+    public void trace(String msg, Throwable t) {
+        log(TRACE, msg, t);
+    }
+
+    @Override
+    public void warn(String msg) {
+        log(WARN, msg);
+    }
+
+    @Override
+    public void warn(String format, Object arg) {
+        log(WARN, format, arg);
+
+    }
+
+    @Override
+    public void warn(String format, Object arg1, Object arg2) {
+        log(WARN, format, arg1, arg2);
+    }
+
+    @Override
+    public void warn(String format, Object[] argArray) {
+        log(WARN, format, argArray);
+    }
+
+    @Override
+    public void warn(String msg, Throwable t) {
+        log(WARN, msg, t);
+    }
+
+    private void log(String level, String msg) {
+        writer.print(level);
+        writer.print(" ");
+        writer.print(msg);
+        writer.println("<br/>");
+    }
+
+    private void log(String level, String format, Object arg) {
+        log(level, MessageFormatter.format(format, arg).getMessage());
+    }
+
+    private void log(String level, String format, Object arg1, Object arg2) {
+        log(level, MessageFormatter.format(format, arg1, arg2).getMessage());
+    }
+
+    private void log(String level, String format, Object[] argArray) {
+        log(level, MessageFormatter.arrayFormat(format, argArray).getMessage());
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/RunFiddleServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/RunFiddleServlet.java
@@ -19,7 +19,22 @@
  */
 package com.adobe.acs.tools.fiddle.impl;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+
+import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.ReferenceCardinality;
+import org.apache.felix.scr.annotations.ReferencePolicy;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.sling.api.SlingConstants;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -27,25 +42,30 @@ import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestDispatcherOptions;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.api.scripting.SlingScript;
+import org.apache.sling.api.scripting.SlingScriptHelper;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
+import org.apache.sling.scripting.core.ScriptHelper;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.Map;
+import com.adobe.acs.tools.fiddle.impl.helper.DummyRequest;
+import com.adobe.acs.tools.fiddle.impl.helper.DummyResponse;
+import com.adobe.acs.tools.fiddle.impl.helper.SyntheticGraniteWorkItem;
+import com.adobe.acs.tools.fiddle.impl.helper.SyntheticGraniteWorkflowData;
+import com.adobe.acs.tools.fiddle.impl.helper.SyntheticGraniteWorkflowSession;
+import com.adobe.granite.workflow.exec.ScriptContextProvider;
 
 @SuppressWarnings("serial")
 @SlingServlet(resourceTypes = "acs-tools/components/aemfiddle", selectors = "run", methods = "POST")
+@Reference(referenceInterface = ScriptContextProvider.class, policy = ReferencePolicy.DYNAMIC,
+        cardinality = ReferenceCardinality.OPTIONAL_MULTIPLE)
 public class RunFiddleServlet extends SlingAllMethodsServlet {
     private static final Logger log = LoggerFactory.getLogger(RunFiddleServlet.class);
 
@@ -56,13 +76,22 @@ public class RunFiddleServlet extends SlingAllMethodsServlet {
     @Reference
     private EventAdmin eventAdmin;
 
+    private List<ScriptContextProvider> scriptContextProviders = new CopyOnWriteArrayList<ScriptContextProvider>();
+
+    private BundleContext bundleContext;
+
+    @Activate
+    protected void activate(ComponentContext componentContext) {
+        this.bundleContext = componentContext.getBundleContext();
+    }
+
     @Override
     protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
 
         // Clear any previously compiled fiddle scripts as they have a tendency to execute on first executions
-        this.clearCompiledFiddle(request.getResourceResolver());
-
+        final ResourceResolver resourceResolver = request.getResourceResolver();
+        this.clearCompiledFiddle(resourceResolver);
 
         final Resource resource = getResource(request);
 
@@ -70,13 +99,47 @@ public class RunFiddleServlet extends SlingAllMethodsServlet {
         final String ext = request.getParameter("scriptext");
 
         InMemoryScript script = InMemoryScript.set(ext, data);
+        Resource scriptResource = script.toResource(resourceResolver);
 
         // doing this as a synchronous event so we ensure that
         // the JSP has been invalidated
-        Map<String, String> props = Collections.singletonMap(
-                SlingConstants.PROPERTY_PATH, script.getPath());
+        Map<String, String> props = Collections.singletonMap(SlingConstants.PROPERTY_PATH, script.getPath());
         eventAdmin.sendEvent(new Event(SlingConstants.TOPIC_RESOURCE_CHANGED, props));
 
+        if (Boolean.parseBoolean(request.getParameter("runAsWorkflow"))) {
+            SlingScript slingScript = scriptResource.adaptTo(SlingScript.class);
+
+            DummyRequest req = new DummyRequest(scriptResource, resourceResolver);
+            DummyResponse res = new DummyResponse();
+            SlingScriptHelper helper = new ScriptHelper(bundleContext, slingScript, req, res);
+
+            SlingBindings bindings = new SlingBindings();
+            bindings.put("scriptHelper", helper);
+            SyntheticGraniteWorkflowData workflowData = new SyntheticGraniteWorkflowData("JCR_PATH", resource.getPath());
+            SyntheticGraniteWorkItem workItem = new SyntheticGraniteWorkItem(workflowData);
+            bindings.put("graniteWorkItem", workItem);
+            bindings.put("graniteWorkflowSession", new SyntheticGraniteWorkflowSession(resourceResolver));
+            bindings.put("args", new String[0]);
+            // todo - metadata map;
+            bindings.setRequest(req);
+            bindings.setResponse(res);
+
+            // add additional variables to bindings via ScriptContextProvider services
+            if (scriptContextProviders != null && scriptContextProviders.size() > 0) {
+                for (ScriptContextProvider scriptContextProvider : scriptContextProviders) {
+                    scriptContextProvider.addContext(bindings);
+                }
+            }
+            bindings.put("log", new ResponseLogger(response));
+
+            slingScript.eval(bindings);
+        } else {
+            fiddleAsNormalScript(resource, request, response);
+        }
+    }
+
+    private void fiddleAsNormalScript(final Resource resource, SlingHttpServletRequest request,
+            SlingHttpServletResponse response) throws ServletException, IOException {
         final RequestDispatcherOptions options = new RequestDispatcherOptions();
         options.setForceResourceType(Constants.PSEDUO_COMPONENT_PATH);
         options.setReplaceSelectors("");
@@ -135,6 +198,14 @@ public class RunFiddleServlet extends SlingAllMethodsServlet {
                 }
             }
         }
+    }
+
+    protected void bindScriptContextProvider(ScriptContextProvider scriptContextProvider) {
+        scriptContextProviders.add(scriptContextProvider);
+    }
+
+    protected void unbindScriptContextProvider(ScriptContextProvider scriptContextProvider) {
+        scriptContextProviders.remove(scriptContextProvider);
     }
 
     private static class GetRequest extends SlingHttpServletRequestWrapper {

--- a/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/DummyRequest.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/DummyRequest.java
@@ -1,0 +1,400 @@
+/*
+ * #%L
+ * ACS AEM Tools Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.tools.fiddle.impl.helper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.Principal;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpSession;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.request.RequestDispatcherOptions;
+import org.apache.sling.api.request.RequestParameter;
+import org.apache.sling.api.request.RequestParameterMap;
+import org.apache.sling.api.request.RequestPathInfo;
+import org.apache.sling.api.request.RequestProgressTracker;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+
+public final class DummyRequest implements SlingHttpServletRequest {
+    private final ResourceResolver resourceResolver;
+    private final Resource resource;
+
+    public DummyRequest(Resource r, ResourceResolver rr) {
+        this.resource = r;
+        this.resourceResolver = rr;
+    }
+
+    @Override
+    public String getAuthType() {
+        return null;
+    }
+
+    @Override
+    public Cookie[] getCookies() {
+        return null;
+    }
+
+    @Override
+    public long getDateHeader(String name) {
+        return 0;
+    }
+
+    @Override
+    public String getHeader(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration getHeaders(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration getHeaderNames() {
+        return null;
+    }
+
+    @Override
+    public int getIntHeader(String name) {
+        return 0;
+    }
+
+    @Override
+    public String getMethod() {
+        return null;
+    }
+
+    @Override
+    public String getPathInfo() {
+        return null;
+    }
+
+    @Override
+    public String getPathTranslated() {
+        return null;
+    }
+
+    @Override
+    public String getContextPath() {
+        return null;
+    }
+
+    @Override
+    public String getQueryString() {
+        return null;
+    }
+
+    @Override
+    public String getRemoteUser() {
+        return null;
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        return false;
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return null;
+    }
+
+    @Override
+    public String getRequestedSessionId() {
+        return null;
+    }
+
+    @Override
+    public String getRequestURI() {
+        return null;
+    }
+
+    @Override
+    public StringBuffer getRequestURL() {
+        return null;
+    }
+
+    @Override
+    public String getServletPath() {
+        return null;
+    }
+
+    @Override
+    public HttpSession getSession(boolean create) {
+        return null;
+    }
+
+    @Override
+    public HttpSession getSession() {
+        return null;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdValid() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromCookie() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromURL() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromUrl() {
+        return false;
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration getAttributeNames() {
+        return null;
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        return null;
+    }
+
+    @Override
+    public void setCharacterEncoding(String env) throws UnsupportedEncodingException {
+    }
+
+    @Override
+    public int getContentLength() {
+        return 0;
+    }
+
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+        return null;
+    }
+
+    @Override
+    public String getParameter(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration getParameterNames() {
+        return null;
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        return null;
+    }
+
+    @Override
+    public Map getParameterMap() {
+        return null;
+    }
+
+    @Override
+    public String getProtocol() {
+        return null;
+    }
+
+    @Override
+    public String getScheme() {
+        return null;
+    }
+
+    @Override
+    public String getServerName() {
+        return null;
+    }
+
+    @Override
+    public int getServerPort() {
+        return 0;
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+        return null;
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        return null;
+    }
+
+    @Override
+    public String getRemoteHost() {
+        return null;
+    }
+
+    @Override
+    public void setAttribute(String name, Object o) {
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+    }
+
+    @Override
+    public Locale getLocale() {
+        return null;
+    }
+
+    @Override
+    public Enumeration getLocales() {
+        return null;
+    }
+
+    @Override
+    public boolean isSecure() {
+        return false;
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String path) {
+        return null;
+    }
+
+    @Override
+    public String getRealPath(String path) {
+        return null;
+    }
+
+    @Override
+    public int getRemotePort() {
+        return 0;
+    }
+
+    @Override
+    public String getLocalName() {
+        return null;
+    }
+
+    @Override
+    public String getLocalAddr() {
+        return null;
+    }
+
+    @Override
+    public int getLocalPort() {
+        return 0;
+    }
+
+    @Override
+    public <AdapterType> AdapterType adaptTo(Class<AdapterType> type) {
+        return null;
+    }
+
+    @Override
+    public Resource getResource() {
+        return resource;
+    }
+
+    @Override
+    public ResourceResolver getResourceResolver() {
+        return resourceResolver;
+    }
+
+    @Override
+    public RequestPathInfo getRequestPathInfo() {
+        return null;
+    }
+
+    @Override
+    public RequestParameter getRequestParameter(String name) {
+        return null;
+    }
+
+    @Override
+    public RequestParameter[] getRequestParameters(String name) {
+        return null;
+    }
+
+    @Override
+    public RequestParameterMap getRequestParameterMap() {
+        return null;
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String path, RequestDispatcherOptions options) {
+        return null;
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(Resource resource, RequestDispatcherOptions options) {
+        return null;
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(Resource resource) {
+        return null;
+    }
+
+    @Override
+    public Cookie getCookie(String name) {
+        return null;
+    }
+
+    @Override
+    public String getResponseContentType() {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getResponseContentTypes() {
+        return null;
+    }
+
+    @Override
+    public ResourceBundle getResourceBundle(Locale locale) {
+        return null;
+    }
+
+    @Override
+    public ResourceBundle getResourceBundle(String baseName, Locale locale) {
+        return null;
+    }
+
+    @Override
+    public RequestProgressTracker getRequestProgressTracker() {
+        return null;
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/DummyResponse.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/DummyResponse.java
@@ -1,0 +1,178 @@
+/*
+ * #%L
+ * ACS AEM Tools Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.tools.fiddle.impl.helper;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Locale;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+
+import org.apache.sling.api.SlingHttpServletResponse;
+
+public class DummyResponse implements SlingHttpServletResponse {
+
+    @Override
+    public void addCookie(Cookie cookie) {
+    }
+
+    @Override
+    public boolean containsHeader(String name) {
+        return false;
+    }
+
+    @Override
+    public String encodeURL(String url) {
+        return null;
+    }
+
+    @Override
+    public String encodeRedirectURL(String url) {
+        return null;
+    }
+
+    @Override
+    public String encodeUrl(String url) {
+        return null;
+    }
+
+    @Override
+    public String encodeRedirectUrl(String url) {
+        return null;
+    }
+
+    @Override
+    public void sendError(int sc, String msg) throws IOException {
+    }
+
+    @Override
+    public void sendError(int sc) throws IOException {
+    }
+
+    @Override
+    public void sendRedirect(String location) throws IOException {
+    }
+
+    @Override
+    public void setDateHeader(String name, long date) {
+    }
+
+    @Override
+    public void addDateHeader(String name, long date) {
+    }
+
+    @Override
+    public void setHeader(String name, String value) {
+    }
+
+    @Override
+    public void addHeader(String name, String value) {
+    }
+
+    @Override
+    public void setIntHeader(String name, int value) {
+    }
+
+    @Override
+    public void addIntHeader(String name, int value) {
+    }
+
+    @Override
+    public void setStatus(int sc) {
+    }
+
+    @Override
+    public void setStatus(int sc, String sm) {
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        return null;
+    }
+
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException {
+        return null;
+    }
+
+    @Override
+    public PrintWriter getWriter() throws IOException {
+        return null;
+    }
+
+    @Override
+    public void setCharacterEncoding(String charset) {
+    }
+
+    @Override
+    public void setContentLength(int len) {
+    }
+
+    @Override
+    public void setContentType(String type) {
+    }
+
+    @Override
+    public void setBufferSize(int size) {
+    }
+
+    @Override
+    public int getBufferSize() {
+        return 0;
+    }
+
+    @Override
+    public void flushBuffer() throws IOException {
+    }
+
+    @Override
+    public void resetBuffer() {
+
+    }
+    @Override
+    public boolean isCommitted() {
+        return false;
+    }
+
+    @Override
+    public void reset() {
+    }
+
+    @Override
+    public void setLocale(Locale loc) {
+    }
+
+    @Override
+    public Locale getLocale() {
+        return null;
+    }
+
+    @Override
+    public <AdapterType> AdapterType adaptTo(Class<AdapterType> type) {
+        return null;
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/SyntheticGraniteMetaDataMap.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/SyntheticGraniteMetaDataMap.java
@@ -1,0 +1,118 @@
+/*
+ * #%L
+ * ACS AEM Tools Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.tools.fiddle.impl.helper;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+
+import com.adobe.granite.workflow.metadata.MetaDataMap;
+
+public final class SyntheticGraniteMetaDataMap implements MetaDataMap {
+
+    private ValueMap metaDataMap;
+
+    public SyntheticGraniteMetaDataMap() {
+        this.metaDataMap = new ValueMapDecorator(new HashMap<String, Object>());
+    }
+
+    public SyntheticGraniteMetaDataMap(Map<String, Object> map) {
+        if (map == null) {
+            map = new HashMap<String, Object>();
+        }
+
+        this.metaDataMap = new ValueMapDecorator(map);
+    }
+
+    @Override
+    public <T> T get(String s, Class<T> tClass) {
+        return this.metaDataMap.get(s, tClass);
+    }
+
+    @Override
+    public <T> T get(String s, T t) {
+        return this.metaDataMap.get(s, t);
+    }
+
+    @Override
+    public int size() {
+        return this.metaDataMap.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.metaDataMap.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object o) {
+        return this.metaDataMap.containsKey(o);
+    }
+
+    @Override
+    public boolean containsValue(Object o) {
+        return this.metaDataMap.containsValue(o);
+    }
+
+    @Override
+    public Object get(Object o) {
+        return this.metaDataMap.get(o);
+    }
+
+    @Override
+    public Object put(String s, Object o) {
+        return this.metaDataMap.put(s, o);
+    }
+
+    @Override
+    public Object remove(Object o) {
+        return this.metaDataMap.remove(o);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ?> map) {
+        this.metaDataMap.putAll(map);
+    }
+
+    @Override
+    public void clear() {
+        this.metaDataMap.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return this.metaDataMap.keySet();
+    }
+
+    @Override
+    public Collection<Object> values() {
+        return this.metaDataMap.values();
+    }
+
+    @Override
+    public Set<Entry<String, Object>> entrySet() {
+        return this.metaDataMap.entrySet();
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/SyntheticGraniteWorkItem.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/SyntheticGraniteWorkItem.java
@@ -1,0 +1,129 @@
+/*
+ * #%L
+ * ACS AEM Tools Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.tools.fiddle.impl.helper;
+
+import java.util.Date;
+import java.util.UUID;
+
+import com.adobe.granite.workflow.exec.Status;
+import com.adobe.granite.workflow.exec.WorkItem;
+import com.adobe.granite.workflow.exec.Workflow;
+import com.adobe.granite.workflow.exec.WorkflowData;
+import com.adobe.granite.workflow.metadata.MetaDataMap;
+import com.adobe.granite.workflow.model.WorkflowNode;
+
+public final class SyntheticGraniteWorkItem implements WorkItem {
+
+    private static String CURRENT_ASSIGNEE = "Synthetic Workflow";
+
+    private Date timeStarted = null;
+
+    private Date timeEnded = null;
+
+    private UUID uuid = UUID.randomUUID();
+
+    private Workflow workflow;
+
+    private WorkflowData workflowData;
+
+    private MetaDataMap metaDataMap = new SyntheticGraniteMetaDataMap();
+
+    public SyntheticGraniteWorkItem(WorkflowData workflowData) {
+        this.workflowData = workflowData;
+        this.timeStarted = new Date();
+    }
+
+    public void setWorkflow(SyntheticGraniteWorkflow workflow) {
+        workflow.setActiveWorkItem(this);
+        this.workflow = workflow;
+    }
+
+    public void setTimeEnded(Date timeEnded) {
+        if (timeEnded == null) {
+            this.timeEnded = null;
+        } else {
+            this.timeEnded = (Date) timeEnded.clone();
+        }
+    }
+
+    @Override
+    public String getId() {
+        return uuid.toString() + "_" + this.getWorkflowData().getPayload();
+    }
+
+    @Override
+    public Date getTimeStarted() {
+        return this.timeStarted == null ? null : (Date) this.timeStarted.clone();
+    }
+
+    @Override
+    public Date getTimeEnded() {
+        return this.timeEnded == null ? null : (Date) this.timeEnded.clone();
+    }
+
+    @Override
+    public WorkflowData getWorkflowData() {
+        return this.workflowData;
+    }
+
+    @Override
+    public String getCurrentAssignee() {
+        return CURRENT_ASSIGNEE;
+    }
+
+    /**
+     * This metadata map is local to this Workflow Item. This Map will change with each
+     * WorkflowProcess step.
+     *
+     * @return the WorkItem's MetaDataMap
+     */
+    @Override
+    public MetaDataMap getMetaDataMap() {
+        return this.metaDataMap;
+    }
+
+    @Override
+    public Workflow getWorkflow() {
+        return this.workflow;
+    }
+
+    @Override
+    public Status getStatus() {
+       return Status.ACTIVE;
+    }
+
+    /* Unimplemented Methods */
+
+    @Override
+    public WorkflowNode getNode() {
+        return null;
+    }
+
+    @Override
+    public String getItemType() {
+        return null;
+    }
+
+    @Override
+    public String getItemSubType() {
+        return null;
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/SyntheticGraniteWorkflow.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/SyntheticGraniteWorkflow.java
@@ -1,0 +1,102 @@
+package com.adobe.acs.tools.fiddle.impl.helper;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import com.adobe.granite.workflow.exec.WorkItem;
+import com.adobe.granite.workflow.exec.Workflow;
+import com.adobe.granite.workflow.exec.WorkflowData;
+import com.adobe.granite.workflow.exec.filter.WorkItemFilter;
+import com.adobe.granite.workflow.metadata.MetaDataMap;
+import com.adobe.granite.workflow.model.WorkflowModel;
+
+public final class SyntheticGraniteWorkflow implements Workflow {
+
+    private String id;
+
+    private Date timeStarted;
+
+    private WorkflowData workflowData;
+
+    private SyntheticGraniteWorkItem activeWorkItem;
+
+    public SyntheticGraniteWorkflow(String id, WorkflowData workflowData) {
+        this.id = id;
+        this.workflowData = workflowData;
+        this.timeStarted = new Date();
+    }
+
+    @Override
+    public String getId() {
+        return this.id;
+    }
+
+    @Override
+    public List<WorkItem> getWorkItems() {
+        return Arrays.asList(new WorkItem[]{this.activeWorkItem});
+    }
+
+    @Override
+    public List<WorkItem> getWorkItems(WorkItemFilter workItemFilter) {
+        List<WorkItem> filtered = new ArrayList<WorkItem>();
+
+        for (WorkItem workItem : this.getWorkItems()) {
+            if (workItemFilter.doInclude(workItem)) {
+                filtered.add(workItem);
+            }
+        }
+
+        return filtered;
+    }
+
+    @Override
+    public WorkflowModel getWorkflowModel() {
+        return null;
+    }
+
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+
+    @Override
+    public String getState() {
+        return "Synthetic Running";
+    }
+
+    @Override
+    public String getInitiator() {
+        return "Synthetic Workflow";
+    }
+
+    @Override
+    public Date getTimeStarted() {
+        return (Date) this.timeStarted.clone();
+    }
+
+    @Override
+    public Date getTimeEnded() {
+        return null;
+    }
+
+    @Override
+    public WorkflowData getWorkflowData() {
+        return this.workflowData;
+    }
+
+    public void setWorkflowData(WorkflowData workflowData) {
+        this.workflowData = workflowData;
+    }
+
+    @Override
+    public MetaDataMap getMetaDataMap() {
+        return this.getWorkflowData().getMetaDataMap();
+    }
+
+    public void setActiveWorkItem(SyntheticGraniteWorkItem workItem) {
+        this.activeWorkItem = workItem;
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/SyntheticGraniteWorkflow.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/SyntheticGraniteWorkflow.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Tools Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.tools.fiddle.impl.helper;
 
 import java.util.ArrayList;

--- a/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/SyntheticGraniteWorkflowData.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/SyntheticGraniteWorkflowData.java
@@ -1,0 +1,52 @@
+/*
+ * #%L
+ * ACS AEM Tools Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.tools.fiddle.impl.helper;
+
+import com.adobe.granite.workflow.exec.WorkflowData;
+import com.adobe.granite.workflow.metadata.MetaDataMap;
+
+public class SyntheticGraniteWorkflowData implements WorkflowData {
+    private String payloadType;
+
+    private Object payload;
+
+    private MetaDataMap metaDataMap = new SyntheticGraniteMetaDataMap();
+
+    public SyntheticGraniteWorkflowData(String payloadType, Object payload) {
+        this.payloadType = payloadType;
+        this.payload = payload;
+    }
+
+    @Override
+    public Object getPayload() {
+        return this.payload;
+    }
+
+    @Override
+    public String getPayloadType() {
+        return this.payloadType;
+    }
+
+    @Override
+    public MetaDataMap getMetaDataMap() {
+        return this.metaDataMap;
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/SyntheticGraniteWorkflowSession.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/helper/SyntheticGraniteWorkflowSession.java
@@ -1,0 +1,301 @@
+/*
+ * #%L
+ * ACS AEM Tools Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.tools.fiddle.impl.helper;
+
+import java.security.AccessControlException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.jcr.Session;
+
+import org.apache.sling.api.resource.ResourceResolver;
+
+import com.adobe.granite.workflow.WorkflowException;
+import com.adobe.granite.workflow.WorkflowSession;
+import com.adobe.granite.workflow.collection.util.ResultSet;
+import com.adobe.granite.workflow.exec.HistoryItem;
+import com.adobe.granite.workflow.exec.InboxItem;
+import com.adobe.granite.workflow.exec.Participant;
+import com.adobe.granite.workflow.exec.Route;
+import com.adobe.granite.workflow.exec.WorkItem;
+import com.adobe.granite.workflow.exec.Workflow;
+import com.adobe.granite.workflow.exec.WorkflowData;
+import com.adobe.granite.workflow.exec.filter.InboxItemFilter;
+import com.adobe.granite.workflow.exec.filter.WorkItemFilter;
+import com.adobe.granite.workflow.model.VersionException;
+import com.adobe.granite.workflow.model.WorkflowModel;
+import com.adobe.granite.workflow.model.WorkflowModelFilter;
+
+public final class SyntheticGraniteWorkflowSession implements WorkflowSession {
+
+    private final ResourceResolver resourceResolver;
+
+    public SyntheticGraniteWorkflowSession(ResourceResolver resourceResolver) {
+        this.resourceResolver = resourceResolver;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <AdapterType> AdapterType adaptTo(Class<AdapterType> type) {
+        if (ResourceResolver.class == type) {
+            return (AdapterType) resourceResolver;
+        } else if (Session.class == type) {
+            return (AdapterType) resourceResolver.adaptTo(Session.class);
+        }
+
+        return null;
+    }
+
+    @Override
+    public void deployModel(WorkflowModel model) throws WorkflowException {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public WorkflowModel createNewModel(String title) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public WorkflowModel createNewModel(String title, String id) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void deleteModel(String id) throws WorkflowException {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public WorkflowModel[] getModels() throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public WorkflowModel[] getModels(WorkflowModelFilter filter) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ResultSet<WorkflowModel> getModels(long start, long limit) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ResultSet<WorkflowModel> getModels(long start, long limit, WorkflowModelFilter filter)
+            throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public WorkflowModel getModel(String id) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public WorkflowModel getModel(String id, String version) throws WorkflowException, VersionException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Workflow startWorkflow(WorkflowModel model, WorkflowData data) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Workflow startWorkflow(WorkflowModel model, WorkflowData data, Map<String, Object> metaData)
+            throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void terminateWorkflow(Workflow instance) throws WorkflowException {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void resumeWorkflow(Workflow instance) throws WorkflowException {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void suspendWorkflow(Workflow instance) throws WorkflowException {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public WorkItem[] getActiveWorkItems() throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ResultSet<WorkItem> getActiveWorkItems(long start, long limit) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ResultSet<WorkItem> getActiveWorkItems(long start, long limit, WorkItemFilter filter)
+            throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ResultSet<InboxItem> getActiveInboxItems(long start, long limit, InboxItemFilter filter)
+            throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ResultSet<InboxItem> getActiveInboxItems(long start, long limit, String itemSubType, InboxItemFilter filter)
+            throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public WorkItem[] getAllWorkItems() throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ResultSet<WorkItem> getAllWorkItems(long start, long limit) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public WorkItem getWorkItem(String id) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Workflow[] getWorkflows(String[] states) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ResultSet<Workflow> getWorkflows(String[] states, long start, long limit) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Workflow[] getAllWorkflows() throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Workflow getWorkflow(String id) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void complete(WorkItem item, Route route) throws WorkflowException {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public List<Route> getRoutes(WorkItem item, boolean expand) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public List<Route> getBackRoutes(WorkItem item, boolean expand) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public WorkflowData newWorkflowData(String payloadType, Object payload) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Iterator<Participant> getDelegates(WorkItem item) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void delegateWorkItem(WorkItem item, Participant participant)
+            throws WorkflowException, AccessControlException {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public List<HistoryItem> getHistory(Workflow instance) throws WorkflowException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void updateWorkflowData(Workflow instance, WorkflowData data) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void logout() {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public boolean isSuperuser() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public void restartWorkflow(Workflow workflow) throws WorkflowException {
+        // TODO Auto-generated method stub
+
+    }
+
+}

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/aemfiddle/clientlibs/js/app-controller.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/aemfiddle/clientlibs/js/app-controller.js
@@ -77,7 +77,8 @@ aemFiddle.controller('MainCtrl', ['$scope', '$http', '$timeout', function($scope
         lastModifiedAt: 0,
         resource: '',
         scriptData: '',
-        scriptExt: $scope.data.defaults.scriptExt
+        scriptExt: $scope.data.defaults.scriptExt,
+        runAsWorkflow: false
     };
 
     /* Results; Drives output view */
@@ -152,7 +153,8 @@ aemFiddle.controller('MainCtrl', ['$scope', '$http', '$timeout', function($scope
             data: $.param({
                 'scriptdata': aemFiddle.ace.input.editor.getValue(),
                 'scriptext' : $scope.data.src.scriptExt,
-                'resource': $scope.data.src.resource
+                'resource': $scope.data.src.resource,
+                'runAsWorkflow' : $scope.data.src.runAsWorkflow
             })
         }).success(function(data, status, headers, config) {
                 /*

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/aemfiddle/includes/header.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/aemfiddle/includes/header.jsp
@@ -45,6 +45,11 @@
                placeholder="Absolute resource path"
                class="resource header-item"/>
 
+        <%-- Execute as Workflow --%>
+        <label><input
+                ng-model="data.src.runAsWorkflow"
+                type="checkbox"><span>Run as Workflow</span></label>
+
         <span class="divider"></span>
 
         <%-- Run Code Button --%>


### PR DESCRIPTION
This isn't quite done, but is a start of adding support into AEM Fiddle for executing Workflow process scripts. It had occurred to me to create a new tool, but then it seemed like AEM Fiddle has a significant amount of the necessary functionality.

Unfortunately, the Synthetic Workflow objects from ACS AEM Commons can't be reused as the workflow engine operates at the Granite level.
