### PR TITLE
Feature/user event data

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/tools/csv_asset_importer/impl/CsvAssetImporterServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/csv_asset_importer/impl/CsvAssetImporterServlet.java
@@ -116,6 +116,9 @@ public class CsvAssetImporterServlet extends SlingAllMethodsServlet {
                 final List<String> failures = new ArrayList<String>();
 
                 log.info(params.toString());
+
+                request.getResourceResolver().adaptTo(Session.class).getWorkspace().getObservationManager().setUserData("acs-aem-tools.csv-asset-importer");
+
                 while (rows.hasNext()) {
                     final String[] row = rows.next();
 

--- a/bundle/src/main/java/com/adobe/acs/tools/csv_resource_type_updater/impl/CsvResourceTypeUpdateServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/csv_resource_type_updater/impl/CsvResourceTypeUpdateServlet.java
@@ -35,6 +35,7 @@ import org.apache.sling.commons.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.jcr.Session;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -75,6 +76,8 @@ public class CsvResourceTypeUpdateServlet extends SlingAllMethodsServlet {
             final Iterator<String[]> rows = CsvUtil.getRowsFromCsv(params);
 
             try {
+                request.getResourceResolver().adaptTo(Session.class).getWorkspace().getObservationManager().setUserData("acs-aem-tools.csv-resource-type-updater");
+
                 final Result result = this.update(request.getResourceResolver(), params, rows);
 
                 if (log.isInfoEnabled()) {

--- a/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/RunFiddleServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/RunFiddleServlet.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import java.io.File;
@@ -99,6 +100,12 @@ public class RunFiddleServlet extends SlingAllMethodsServlet {
 
         // Suppress ACS AEM Commons - Component Error Handler from capturing errors
         request.setAttribute("com.adobe.acs.commons.wcm.component-error-handler.suppress", true);
+
+        try {
+            request.getResourceResolver().adaptTo(Session.class).getWorkspace().getObservationManager().setUserData("acs-aem-tools.aem-fiddle");
+        } catch (RepositoryException e) {
+            log.warn("Unable to set [ user-event-data = acs-aem-tools.test-page-generator ] for fiddle execution.", e);
+        }
 
         RequestDispatcher dispatcher = request.getRequestDispatcher(resource, options);
         GetRequest getRequest = new GetRequest(request);

--- a/bundle/src/main/java/com/adobe/acs/tools/tag_maker/impl/TagMakerServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/tag_maker/impl/TagMakerServlet.java
@@ -50,6 +50,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 import javax.servlet.ServletException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -211,6 +212,8 @@ public class TagMakerServlet extends SlingAllMethodsServlet {
             final Iterator<String[]> rows = csv.read(is, charset);
 
             try {
+                request.getResourceResolver().adaptTo(Session.class).getWorkspace().getObservationManager().setUserData("acs-aem-tools.tag-maker");
+
                 final List<String> result = this.makeTags(tagManager, tagDataConverters, rows);
 
                 try {

--- a/bundle/src/main/java/com/adobe/acs/tools/test_page_generator/impl/TestPageGeneratorServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/test_page_generator/impl/TestPageGeneratorServlet.java
@@ -82,6 +82,8 @@ public class TestPageGeneratorServlet extends SlingAllMethodsServlet {
         response.setCharacterEncoding("UTF-8");
 
         try {
+            request.getResourceResolver().adaptTo(Session.class).getWorkspace().getObservationManager().setUserData("acs-aem-tools.test-page-generator");
+
             final JSONObject json = this.generatePages(request.getResourceResolver(), new Parameters(request));
             response.getWriter().write(json.toString(2));
         } catch (JSONException e) {


### PR DESCRIPTION
Resolves #149 

ACS Content creation/manipulation tooling should set user-event-data so they can easily be ignored by launchers. The reduces the changes Launchers are disabled and then not re-enabled.

* CSV Asset Importer -> acs-aem-tools.csv-asset-importer
* CSV Resource Type Updater -> acs-aem-tools.csv-resource-type-updater
* Tag Maker -> acs-aem-tools.tag-maker
* Test Page Generator -> acs-aem-tools.test-page-generator
* AEM Fiddle -> acs-aem-tools.aem-fiddle

![image](https://cloud.githubusercontent.com/assets/1451868/16752710/c10ce5de-47b1-11e6-8576-dd9dc8676a7b.png)
