### PR TITLE
So that acs commons bundle doesn't get installed and doesn't conflict…

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -206,6 +206,7 @@
             <artifactId>acs-aem-commons-bundle</artifactId>
             <version>1.10.2</version>
             <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>


### PR DESCRIPTION
… with other versions of acs commons.
