### PR TITLE
#147 - Proper fix for removing compiled JSPs from filesystem for AEM …

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/RunFiddleServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/RunFiddleServlet.java
@@ -60,9 +60,9 @@ public class RunFiddleServlet extends SlingAllMethodsServlet {
     private static final String COMPILED_JSP = "org/apache/jsp/apps/acs_002dtools/components/aemfiddle";
 
     private static final String[] COMPILED_JSP_FILES = new String[]{
-            "org/apache/jsp/apps/acs_002dtools/components/aemfiddle_jsp.class",
-            "org/apache/jsp/apps/acs_002dtools/components/aemfiddle_jsp.deps",
-            "org/apache/jsp/apps/acs_002dtools/components/aemfiddle_jsp.java"
+            "org/apache/jsp/apps/acs_002dtools/components/aemfiddle/fiddle/fiddle_jsp.class",
+            "org/apache/jsp/apps/acs_002dtools/components/aemfiddle/fiddle/fiddle_jsp.deps",
+            "org/apache/jsp/apps/acs_002dtools/components/aemfiddle/fiddle/fiddle_jsp.java"
     };
 
     private File fileRoot;


### PR DESCRIPTION
…6.1/6.2 before each fiddle execution.

Prior fix 6d0a549f37e38a7b4c9b26644fc4f2f82b611c30 removed incorrect compiled JSPs.