### PR TITLE
hide credentials from source field in vlt-rcp

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
@@ -26,7 +26,7 @@ angular.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications'])
 
     $scope.rcp_uris = ['/system/jackrabbit/filevault/rcp', '/libs/granite/packaging/rcp'];
 
-    $scope.task_src = 'http://admin:admin@localhost:4502/crx/server/-/jcr:root/content/dam/my-site';
+    $scope.task_src = 'http://localhost:4502/crx/server/-/jcr:root/content/dam/my-site';
 
     $scope.task_dst = '/content/dam/my-site';
 
@@ -151,12 +151,12 @@ angular.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications'])
     };
 
     $scope.create = function () {
-        var i = 0,
+        var src =  $scope.task_src.replace("://","://"+$scope.task_src_credentials+"@"), i = 0,
             excludes = [],
             cmd = {
                 "cmd": "create",
                 "id": $scope.task_id,
-                "src": $scope.task_src,
+                "src": src,
                 "dst": $scope.task_dst,
                 "batchsize": $scope.task_batchSize || 1024,
                 "update": $scope.checkboxModel.update,
@@ -165,7 +165,6 @@ angular.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications'])
                 "noOrdering": $scope.checkboxModel.noOrdering,
                 "throttle": $scope.task_throttle || 0
             };
-
         if ($scope.task_resumeFrom !== "") {
             cmd.resumeFrom = $scope.task_resumeFrom;
         }
@@ -192,7 +191,7 @@ angular.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications'])
 
 
     $scope.reset = function() {
-        var taskSrc = 'http://admin:admin@localhost:4502/crx/server/-/jcr:root/content/dam/my-site',
+        var taskSrc = 'http://localhost:4502/crx/server/-/jcr:root/content/dam/my-site',
             taskDst = '/content/dam/my-site',
             taskBatchSize = '1024',
             taskThrottle = '',
@@ -227,4 +226,13 @@ angular.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications'])
         }
     }, 5000);
 
-}]);
+}]).filter('removeCredentials', function() {
+    return function(input) {
+        /*
+        The regex causes jslint error
+         You can 'fix' the warning by telling JSLint to ignore it: add regexp: true to your JSLint settings at the top of the file.
+         http://stackoverflow.com/questions/10793814/how-to-rectify-insecure-error-in-jslint
+         */
+        return input.replace(/:\/\/.*@/,"//");
+    };
+});

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/content.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/content.jsp
@@ -133,7 +133,8 @@
                         </td>
                         <td class="coral-Table-cell">
                             <ul>
-                                <li>Source: {{ task.src }}</li>
+                                <li>Source: {{ task.src | removeCredentials
+                                    }}</li>
                                 <li>Destination: {{ task.dst }}</li>
                             </ul>
 

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-modal.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-modal.jsp
@@ -34,20 +34,29 @@
 
                 <label class="coral-Form-fieldlabel">Task Id</label>
                 <input class="coral-Form-field coral-Textfield" type="text"
-                               ng-model="task_id"
-                               name="id"/>
+                       ng-model="task_id"
+                       name="id"/>
 
                 <label class="coral-Form-fieldlabel">Source</label>
                 <input class="coral-Form-field coral-Textfield" type="text"
-                               ng-model="task_src"
-                               name="src"
-                               placeholder="http://admin:admin@localhost:4502/crx/server/-/jcr:root/content/dam/my-site"/>
+                       ng-model="task_src"
+                       name="src"
+                       placeholder="http://localhost:4502/crx/server/-/jcr:root/content/dam/my-site"/>
+                <div class="coral-Form-fieldwrapper">
+                    <label class="coral-Form-fieldlabel">Source Credentials
+                    </label>
+                    <input class="coral-Form-field coral-Textfield" type="password"
+                           ng-model="task_src_credentials"
+                           name="src_password"
+                    /> <span class="coral-Form-fieldinfo coral-Icon coral-Icon--infoCircle coral-Icon--sizeS" data-init="quicktip" data-quicktip-type="info" data-quicktip-arrow="right" data-quicktip-content="userid:password"></span>
+                </div>
+
 
                 <label class="coral-Form-fieldlabel">Destination</label>
                 <input class="coral-Form-field coral-Textfield" type="text"
-                               ng-model="task_dst"
-                               name="dst"
-                               placeholder="/content/dam/my-site"/>
+                       ng-model="task_dst"
+                       name="dst"
+                       placeholder="/content/dam/my-site"/>
 
                 <label class="coral-Form-fieldlabel">Recursive</label>
                 <span class="coral-Form-field coral-Switch">
@@ -79,24 +88,24 @@
 
                 <label class="coral-Form-fieldlabel">Resume from</label>
                 <input class="coral-Form-field coral-Textfield" type="text"
-                               ng-model="task_resumeFrom"
-                               name="resumeFrom"
-                               placeholder="/content/dam/my-site"/>
+                       ng-model="task_resumeFrom"
+                       name="resumeFrom"
+                       placeholder="/content/dam/my-site"/>
 
                 <label class="coral-Form-fieldlabel">Batch size</label>
                 <input class="coral-Form-field coral-Textfield" type="text"
-                               ng-model="task_batchSize"
-                               name="batchSize"
-                               placeholder="1024"/>
+                       ng-model="task_batchSize"
+                       name="batchSize"
+                       placeholder="1024"/>
 
                 <label class="coral-Form-fieldlabel">Throttle</label>
                 <input class="coral-Form-field coral-Textfield" type="text"
-                               ng-model="task_throttle"
-                               name="throttle"
-                               placeholder="in seconds"/>
+                       ng-model="task_throttle"
+                       name="throttle"
+                       placeholder="in seconds"/>
 
                 <label class="coral-Form-fieldlabel">Excludes</label>
-                 <div class="coral-Form-field excludes">
+                <div class="coral-Form-field excludes">
                     <a class="addButton" ng-click="addExclude()">
                         <i class="coral-Icon coral-Icon--addCircle"></i>
                     </a>
@@ -104,8 +113,8 @@
                         <ul ng-repeat="exclude in excludes track by $index">
                             <li>
                                 <input class="coral-Form-field coral-Textfield" type="text"
-                                        ng-model="exclude.value"
-                                        placeholder="/content/dam/my-site/(en|fr)/documents(/.*)?"/>
+                                       ng-model="exclude.value"
+                                       placeholder="/content/dam/my-site/(en|fr)/documents(/.*)?"/>
 
                                 <a class="removeButton" ng-click="removeExclude($index)"><i class="coral-Icon coral-Icon--minusCircle"></i></a>
                             </li>


### PR DESCRIPTION
The vlt rcp tool shows the user credentials in source and this enhancement uses js to hide the credentials.
Added a new source credentials field 
<img width="1024" alt="screenshot" src="https://cloud.githubusercontent.com/assets/6203088/20149431/33e74d68-a6d7-11e6-869b-c4ba3a262121.png">
 In the js, added the credentials back to the source before onsubmit.
<img width="772" alt="screenshot" src="https://cloud.githubusercontent.com/assets/6203088/20149490/8b30c8a6-a6d7-11e6-97e3-ebdb62d8568b.png">
Added  a filter to remove credentials from showing up in task view
<img width="1019" alt="screenshot" src="https://cloud.githubusercontent.com/assets/6203088/20149524/ab0a2a0a-a6d7-11e6-827c-ebf40a5684dc.png">
This filter will be used as
<img width="703" alt="screenshot" src="https://cloud.githubusercontent.com/assets/6203088/20149545/c0e54e54-a6d7-11e6-830f-08e35ca2465f.png">
 