### PR TITLE
#164 - Only embed the acs-aem-tools-bundle in the ACS Tools content p…

### DIFF
--- a/content/pom.xml
+++ b/content/pom.xml
@@ -52,6 +52,7 @@
                     <embeddeds>
                         <embedded>
                             <groupId>${project.groupId}</groupId>
+                            <artifactId>acs-aem-tools-bundle</artifactId>
                             <target>/apps/acs-tools/install</target>
                         </embedded>
                     </embeddeds>


### PR DESCRIPTION
…ackage

@justinedelson this look ok to you? We inline a few classes from ACS Commons, but dont need the full bundle.