### PR TITLE
Use 6.1 UberJar to fix #168

### DIFF
--- a/bundle-live-reload/pom.xml
+++ b/bundle-live-reload/pom.xml
@@ -56,12 +56,9 @@
             <artifactId>jcr</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.jcr.api</artifactId>
+            <groupId>com.adobe.aem</groupId>
+            <artifactId>uber-jar</artifactId>
+            <classifier>obfuscated-apis</classifier>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -80,27 +77,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.commons.json</artifactId>
-            <version>2.0.6</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.commons.osgi</artifactId>
-            <version>2.2.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.5.10</version>
-        </dependency>
-        <dependency>
-            <groupId>com.adobe.granite</groupId>
-            <artifactId>com.adobe.granite.ui.commons</artifactId>
-            <version>5.5.76</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -48,7 +48,6 @@
                         <Import-Package>
                             org.apache.sling.hc.*;resolution:=optional,
                             ch.qos.logback.*;resolution:=optional,
-                            com.day.cq.widget;resolution:=optional,
                             !org.joda.convert,
                             *
                         </Import-Package>
@@ -142,29 +141,14 @@
             <artifactId>jcr</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.jcr.api</artifactId>
+            <groupId>com.adobe.aem</groupId>
+            <artifactId>uber-jar</artifactId>
+            <classifier>obfuscated-apis</classifier>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <version>2.5</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.commons.json</artifactId>
-            <version>2.0.6</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.settings</artifactId>
-            <version>1.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -179,51 +163,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.day.cq.wcm</groupId>
-            <artifactId>cq-wcm-api</artifactId>
-            <version>5.6.6</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.day.cq</groupId>
-            <artifactId>cq-commons</artifactId>
-            <version>5.6.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.sling</groupId>
-          <artifactId>org.apache.sling.hc.core</artifactId>
-          <version>1.0.4</version>
-          <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.commons.osgi</artifactId>
-            <version>2.1.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.adobe.acs</groupId>
             <artifactId>acs-aem-commons-bundle</artifactId>
             <version>1.10.2</version>
             <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jackrabbit</groupId>
-            <artifactId>jackrabbit-api</artifactId>
-            <version>2.5.3</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.adobe.granite</groupId>
-            <artifactId>com.adobe.granite.ui.commons</artifactId>
-            <version>5.5.76</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jackrabbit</groupId>
-            <artifactId>jackrabbit-jcr-commons</artifactId>
-            <version>2.6.0</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -232,39 +175,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.day.commons</groupId>
-            <artifactId>day-commons-text</artifactId>
-            <version>1.1.8</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.day.cq</groupId>
-            <artifactId>cq-tagging</artifactId>
-            <version>5.6.2</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.9.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.day.cq.dam</groupId>
-            <artifactId>cq-dam-api</artifactId>
-            <version>5.5.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.day.cq.dam</groupId>
-            <artifactId>cq-dam-commons</artifactId>
-            <version>5.5.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.commons.mime</artifactId>
-            <version>2.1.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bundle/src/main/java/com/adobe/acs/tools/clientlib_optimizer/impl/ClientLibOptimizerServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/clientlib_optimizer/impl/ClientLibOptimizerServlet.java
@@ -31,6 +31,9 @@ import java.util.Set;
 
 import javax.servlet.ServletException;
 
+import com.adobe.granite.ui.clientlibs.ClientLibrary;
+import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
+import com.adobe.granite.ui.clientlibs.LibraryType;
 import org.apache.commons.lang.StringUtils;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
@@ -41,10 +44,6 @@ import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.apache.sling.commons.json.JSONArray;
 import org.apache.sling.commons.json.JSONException;
 import org.apache.sling.commons.json.JSONObject;
-
-import com.day.cq.widget.ClientLibrary;
-import com.day.cq.widget.HtmlLibraryManager;
-import com.day.cq.widget.LibraryType;
 
 @SlingServlet(
         label = "ACS AEM Tools - ClientLibrary Optimizer Servlet",

--- a/bundle/src/main/java/com/adobe/acs/tools/clientlib_optimizer/impl/ClientLibraryDependency.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/clientlib_optimizer/impl/ClientLibraryDependency.java
@@ -28,12 +28,11 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import com.adobe.granite.ui.clientlibs.ClientLibrary;
+import com.adobe.granite.ui.clientlibs.LibraryType;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.day.cq.widget.ClientLibrary;
-import com.day.cq.widget.LibraryType;
 
 public class ClientLibraryDependency {
 

--- a/bundle/src/main/java/com/adobe/acs/tools/clientlib_optimizer/impl/ClientLibraryPathComparator.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/clientlib_optimizer/impl/ClientLibraryPathComparator.java
@@ -19,9 +19,9 @@
  */
 package com.adobe.acs.tools.clientlib_optimizer.impl;
 
-import java.util.Comparator;
+import com.adobe.granite.ui.clientlibs.ClientLibrary;
 
-import com.day.cq.widget.ClientLibrary;
+import java.util.Comparator;
 
 public class ClientLibraryPathComparator implements Comparator<ClientLibrary> {
 

--- a/bundle/src/test/java/com/adobe/acs/tools/clientlib_optimizer/impl/ClientLibOptimizerServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/tools/clientlib_optimizer/impl/ClientLibOptimizerServletTest.java
@@ -9,15 +9,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.adobe.granite.ui.clientlibs.ClientLibrary;
+import com.adobe.granite.ui.clientlibs.LibraryType;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.junit.Assert;
-
-import com.day.cq.widget.ClientLibrary;
-import com.day.cq.widget.LibraryType;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClientLibOptimizerServletTest {

--- a/content/pom.xml
+++ b/content/pom.xml
@@ -55,6 +55,11 @@
                             <artifactId>acs-aem-tools-bundle</artifactId>
                             <target>/apps/acs-tools/install</target>
                         </embedded>
+                        <embedded>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>acs-aem-tools-bundle-livereload</artifactId>
+                            <target>/apps/acs-tools/install</target>
+                        </embedded>
                     </embeddeds>
                     <targetURL>http://${crx.host}:${crx.port}/crx/packmgr/service.jsp</targetURL>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -249,15 +249,10 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.apache.sling</groupId>
-                <artifactId>org.apache.sling.api</artifactId>
-                <version>2.3.0</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.sling</groupId>
-                <artifactId>org.apache.sling.jcr.api</artifactId>
-                <version>2.1.0</version>
+                <groupId>com.adobe.aem</groupId>
+                <artifactId>uber-jar</artifactId>
+                <version>6.1.0</version>
+                <classifier>obfuscated-apis</classifier>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
This will now set the minimal version of ACS AEM Tools to be AEM 6.1. IMHO, this is OK at this point.