### PR TITLE
#170 - Moves AEM Fiddle to use new Sling SPI ResourceProvider APIs to…

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -186,6 +186,11 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.api</artifactId>
+            <version>2.11.0</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/FiddleResourceProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/FiddleResourceProvider.java
@@ -2,14 +2,14 @@
  * #%L
  * ACS AEM Tools Bundle
  * %%
- * Copyright (C) 2013 Adobe
+ * Copyright (C) 2017 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,45 +19,13 @@
  */
 package com.adobe.acs.tools.fiddle.impl;
 
-import java.util.Collections;
-import java.util.Iterator;
+import aQute.bnd.annotation.ProviderType;
 
-import javax.servlet.http.HttpServletRequest;
-
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Service;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceProvider;
-import org.apache.sling.api.resource.ResourceResolver;
-
-@Component
-@Service
-@Property(name = "provider.roots", value = "/apps/acs-tools/components/aemfiddle/fiddle")
-public class FiddleResourceProvider implements ResourceProvider {
-
-    public Resource getResource(ResourceResolver resourceResolver, HttpServletRequest request, String path) {
-        return getResource(resourceResolver, path);
-    }
-
-    public Resource getResource(ResourceResolver resourceResolver, String path) {
-        InMemoryScript script = InMemoryScript.get();
-        if (script != null && path.equals(script.getPath())) {
-            return script.toResource(resourceResolver);
-        }
-
-        return null;
-    }
-
-    public Iterator<Resource> listChildren(Resource parent) {
-        if (parent.getPath().equals(Constants.PSEDUO_COMPONENT_PATH)) {
-            InMemoryScript script = InMemoryScript.get();
-            if (script != null) {
-                Resource scriptResource = script.toResource(parent.getResourceResolver());
-                return Collections.singleton(scriptResource).iterator();
-            }
-        }
-        return null;
-    }
-
+@ProviderType
+public interface FiddleResourceProvider {
+    /**
+     * Method that emits a change event for the AEM Fiddle synthetic resource.
+     * @param path the script path to emit the change for
+     */
+    void emitFiddleScriptChange(String path);
 }

--- a/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/FiddleResourceProviderImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/FiddleResourceProviderImpl.java
@@ -1,0 +1,107 @@
+/*
+ * #%L
+ * ACS AEM Tools Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.tools.fiddle.impl;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.observation.ResourceChange;
+import org.apache.sling.spi.resource.provider.ProviderContext;
+import org.apache.sling.spi.resource.provider.ResolveContext;
+import org.apache.sling.spi.resource.provider.ResourceContext;
+import org.apache.sling.spi.resource.provider.ResourceProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+@Component
+@Property(
+        name = ResourceProvider.PROPERTY_ROOT,
+        value = "/apps/acs-tools/components/aemfiddle/fiddle"
+)
+@Service(value = {ResourceProvider.class, FiddleResourceProvider.class})
+public class FiddleResourceProviderImpl extends ResourceProvider implements FiddleResourceProvider {
+    private static final Logger log = LoggerFactory.getLogger(FiddleResourceProviderImpl.class);
+
+    private volatile ProviderContext providerContext;
+
+    public Resource getResource(ResolveContext ctx, String path, ResourceContext resourceContext, Resource parent) {
+        final ResourceResolver resourceResolver = ctx.getResourceResolver();
+        final InMemoryScript script = InMemoryScript.get();
+        if (script != null && path.equals(script.getPath())) {
+            return script.toResource(resourceResolver);
+        }
+
+        return null;
+    }
+
+    public Iterator<Resource> listChildren(ResolveContext ctx, Resource parent) {
+        if (parent.getPath().equals(Constants.PSEDUO_COMPONENT_PATH)) {
+            InMemoryScript script = InMemoryScript.get();
+            if (script != null) {
+                Resource scriptResource = script.toResource(parent.getResourceResolver());
+                return Collections.singleton(scriptResource).iterator();
+            }
+        }
+        return null;
+    }
+
+    public void start(ProviderContext ctx) {
+        super.start(ctx);
+        synchronized (providerContext) {
+            providerContext = ctx;
+        }
+    }
+
+    public void stop() {
+        super.stop();
+        synchronized (providerContext) {
+            providerContext = null;
+        }
+    }
+
+    public void emitFiddleScriptChange(String path) {
+        if (providerContext != null) {
+            synchronized (providerContext) {
+                final List<ResourceChange> resourceChangeList = new ArrayList<ResourceChange>();
+                final ResourceChange resourceChange = new ResourceChange(
+                        ResourceChange.ChangeType.CHANGED,
+                        path,
+                        false,
+                        Collections.<String>emptySet(),
+                        Collections.<String>emptySet(),
+                        Collections.<String>emptySet()
+                );
+
+                resourceChangeList.add(resourceChange);
+                providerContext.getObservationReporter().reportChanges(resourceChangeList, false);
+            }
+        } else {
+            log.warn("Unable to obtain a Observation Changer for AEM Fiddel script resource provider");
+        }
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/RunFiddleServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/fiddle/impl/RunFiddleServlet.java
@@ -22,7 +22,6 @@ package com.adobe.acs.tools.fiddle.impl;
 import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
-import org.apache.sling.api.SlingConstants;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestDispatcherOptions;
@@ -34,8 +33,6 @@ import org.apache.sling.settings.SlingSettingsService;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
-import org.osgi.service.event.Event;
-import org.osgi.service.event.EventAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,9 +43,7 @@ import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Iterator;
-import java.util.Map;
 
 @SuppressWarnings("serial")
 @SlingServlet(resourceTypes = "acs-tools/components/aemfiddle", selectors = "run", methods = "POST")
@@ -68,7 +63,7 @@ public class RunFiddleServlet extends SlingAllMethodsServlet {
     private File fileRoot;
 
     @Reference
-    private EventAdmin eventAdmin;
+    private FiddleResourceProvider fiddleResourceProvider;
 
     @Reference
     private SlingSettingsService slingSettingsService;
@@ -90,9 +85,7 @@ public class RunFiddleServlet extends SlingAllMethodsServlet {
 
         // doing this as a synchronous event so we ensure that
         // the JSP has been invalidated
-        Map<String, String> props = Collections.singletonMap(
-                SlingConstants.PROPERTY_PATH, script.getPath());
-        eventAdmin.sendEvent(new Event(SlingConstants.TOPIC_RESOURCE_CHANGED, props));
+        fiddleResourceProvider.emitFiddleScriptChange(script.getPath());
 
         final RequestDispatcherOptions options = new RequestDispatcherOptions();
         options.setForceResourceType(Constants.PSEDUO_COMPONENT_PATH);


### PR DESCRIPTION
… be compatible with AEM 6.3

Still need to verify what backwards compatibility this breaks (6.2, 6.1, etc.) however this fix does work on AEM 6.3. 

Opening PR for review purposes.
