### PR TITLE
Updating to the latest version of Jacoco (0.7.9) to add Java8 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.6.3.201306030806</version>
+                    <version>0.7.9</version>
                     <executions>
                         <execution>
                             <id>default-prepare-agent</id>


### PR DESCRIPTION
Hey All,

I was trying to contribute a new feature and noticed that `mvn -Panalysis clean install` failed with the following message. Upgrading to Jacoco 0.7.9, which includes Java 8 support, resolved the issue.

------------

objc[46318]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java (0x100c564c0) and /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/lib/libinstrument.dylib (0x1015ec4e0). One of the two will be used. Which one is undefined.
Exception in thread "main" java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:386)
	at sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:401)
Caused by: java.lang.RuntimeException: Class java/util/UUID could not be instrumented.
	at org.jacoco.agent.rt.internal_9dd1198.core.runtime.ModifiedSystemClassRuntime.createFor(ModifiedSystemClassRuntime.java:138)
	at org.jacoco.agent.rt.internal_9dd1198.core.runtime.ModifiedSystemClassRuntime.createFor(ModifiedSystemClassRuntime.java:99)
	at org.jacoco.agent.rt.internal_9dd1198.PreMain.createRuntime(PreMain.java:55)
	at org.jacoco.agent.rt.internal_9dd1198.PreMain.premain(PreMain.java:47)
	... 6 more
Caused by: java.lang.NoSuchFieldException: $jacocoAccess
	at java.lang.Class.getField(Class.java:1703)
	at org.jacoco.agent.rt.internal_9dd1198.core.runtime.ModifiedSystemClassRuntime.createFor(ModifiedSystemClassRuntime.java:136)
	... 9 more
FATAL ERROR in native method: processing of -javaagent failed
/bin/sh: line 1: 46318 Abort trap: 6           /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java -javaagent:/Users/danklco/.m2/repository/org/jacoco/org.jacoco.agent/0.6.3.201306030806/org.jacoco.agent-0.6.3.201306030806-runtime.jar=destfile=/Users/danklco/git/acs-aem-tools/bundle/target/jacoco.exec -jar /Users/danklco/git/acs-aem-tools/bundle/target/surefire/surefirebooter4221114296910878122.jar /Users/danklco/git/acs-aem-tools/bundle/target/surefire/surefire7169956732717114306tmp /Users/danklco/git/acs-aem-tools/bundle/target/surefire/surefire_09007791535951584858tmp

Results :

Tests run: 0, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] ACS AEM Tools - Reactor Project .................... SUCCESS [  1.286 s]
[INFO] ACS AEM Tools Bundle ............................... FAILURE [  3.337 s]
[INFO] ACS AEM Tools Live Reload Bundle ................... SKIPPED
[INFO] ACS AEM Tools Package .............................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 5.342 s
[INFO] Finished at: 2017-02-10T16:45:19-05:00
[INFO] Final Memory: 55M/520M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.19.1:test (default-test) on project acs-aem-tools-bundle: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.19.1:test failed: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /Users/danklco/git/acs-aem-tools/bundle && /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java -javaagent:/Users/danklco/.m2/repository/org/jacoco/org.jacoco.agent/0.6.3.201306030806/org.jacoco.agent-0.6.3.201306030806-runtime.jar=destfile=/Users/danklco/git/acs-aem-tools/bundle/target/jacoco.exec -jar /Users/danklco/git/acs-aem-tools/bundle/target/surefire/surefirebooter4221114296910878122.jar /Users/danklco/git/acs-aem-tools/bundle/target/surefire/surefire7169956732717114306tmp /Users/danklco/git/acs-aem-tools/bundle/target/surefire/surefire_09007791535951584858tmp
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :acs-aem-tools-bundle
