### PR TITLE
Feature/audit log search

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/tools/audit_log_search/AuditLogSearchRequest.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/audit_log_search/AuditLogSearchRequest.java
@@ -1,0 +1,187 @@
+/*
+ * #%L
+ * ACS AEM Tools Bundle
+ * %%
+ * Copyright (C) 2017 Dan Klco
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.tools.audit_log_search;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.UnsupportedRepositoryOperationException;
+
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.jackrabbit.api.security.user.Authorizable;
+import org.apache.jackrabbit.api.security.user.UserManager;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ResourceResolver;
+
+import com.adobe.granite.security.user.UserProperties;
+import com.adobe.granite.security.user.UserPropertiesManager;
+import com.adobe.granite.security.user.UserPropertiesService;
+
+/**
+ * Simple POJO for audit log requests. Handles some of the crufty code around
+ * loading and generating the query.
+ */
+public class AuditLogSearchRequest {
+
+	private static final SimpleDateFormat HTML5_DATETIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm");
+	private static final SimpleDateFormat QUERY_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss");
+
+	private static String getJCRSQLDate(Date date) {
+		return QUERY_DATE_FORMAT.format(date) + ".000Z";
+	}
+
+	{
+		QUERY_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));
+		HTML5_DATETIME_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));
+	}
+
+	private final String contentRoot;
+	private final boolean children;
+	private final String type;
+	private final String user;
+	private final Date startDate;
+	private final Date endDate;
+	private final String order;
+	private Map<String, String> userNames = new HashMap<String, String>();
+
+	private Map<String, String> userPaths = new HashMap<String, String>();
+
+	/**
+	 * Constructs a new AuditLogSearchRequest from the SlingHttpServletRequest
+	 * 
+	 * @param request
+	 *            yep, that's a request... guess what it does
+	 * @throws ParseException
+	 *             an exception occurred parsing the start / end date
+	 */
+	public AuditLogSearchRequest(SlingHttpServletRequest request) throws ParseException {
+		contentRoot = request.getParameter("contentRoot");
+		children = "true".equals(request.getParameter("children"));
+		type = request.getParameter("type");
+		user = request.getParameter("user");
+		startDate = loadDate(request.getParameter("startDate"));
+		endDate = loadDate(request.getParameter("endDate"));
+		order = request.getParameter("order");
+	}
+
+	public String getContentRoot() {
+		return contentRoot;
+	}
+
+	public Date getEndDate() {
+		return endDate;
+	}
+
+	public String getOrder() {
+		return order;
+	}
+
+	public String getQueryParameters() {
+		List<String> expressions = new ArrayList<String>();
+
+		if (!StringUtils.isEmpty(type)) {
+			expressions.add("[cq:type]='" + StringEscapeUtils.escapeSql(type) + "'");
+		}
+		if (!StringUtils.isEmpty(user)) {
+			expressions.add("[cq:userid]='" + StringEscapeUtils.escapeSql(user) + "'");
+		}
+		if (children) {
+			expressions.add("[cq:path] LIKE '" + StringEscapeUtils.escapeSql(contentRoot) + "%'");
+		} else {
+			expressions.add("[cq:path]='" + StringEscapeUtils.escapeSql(contentRoot) + "'");
+		}
+		if (startDate != null) {
+			expressions.add("[cq:time] > CAST('" + getJCRSQLDate(startDate) + "' AS DATE)");
+		}
+		if (endDate != null) {
+			expressions.add("[cq:time] < CAST('" + getJCRSQLDate(endDate) + "' AS DATE)");
+		}
+		String q = StringUtils.join(expressions, " AND ");
+		if (!StringUtils.isEmpty(order)) {
+			q += " ORDER BY " + order;
+		}
+		return q;
+	}
+
+	public Date getStartDate() {
+		return startDate;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public String getUser() {
+		return user;
+	}
+
+	public String getUserName(ResourceResolver resolver, String userId) throws RepositoryException {
+		if (!userNames.containsKey(userId)) {
+			final UserPropertiesManager upm = resolver.adaptTo(UserPropertiesManager.class);
+			UserProperties userProperties = upm.getUserProperties(userId, UserPropertiesService.PROFILE_PATH);
+			String name = userId;
+			if (userProperties != null && !StringUtils.isEmpty(userProperties.getDisplayName())) {
+				name = userProperties.getDisplayName();
+			}
+			userNames.put(userId, name);
+		}
+		return userNames.get(userId);
+	}
+
+	public String getUserPath(ResourceResolver resolver, String userId)
+			throws UnsupportedRepositoryOperationException, RepositoryException {
+		if (!userPaths.containsKey(userId)) {
+			final UserManager userManager = resolver.adaptTo(UserManager.class);
+			final Authorizable usr = userManager.getAuthorizable(userId);
+			if (usr != null) {
+				userPaths.put(userId, usr.getPath());
+			}
+		}
+		return userPaths.get(userId);
+	}
+
+	public boolean isChildren() {
+		return children;
+	}
+
+	private Date loadDate(String dateStr) throws ParseException {
+		Date date = null;
+		if (!StringUtils.isEmpty(dateStr)) {
+			date = HTML5_DATETIME_FORMAT.parse(dateStr);
+		}
+		return date;
+	}
+
+	@Override
+	public String toString() {
+		return "AuditLogSearchRequest [contentRoot=" + contentRoot + ", children=" + children + ", type=" + type
+				+ ", user=" + user + ", startDate=" + startDate + ", endDate=" + endDate + ", order=" + order
+				+ ", userNames=" + userNames + ", userPaths=" + userPaths + "]";
+	}
+
+}

--- a/bundle/src/main/java/com/adobe/acs/tools/audit_log_search/impl/AuditLogSearchServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/audit_log_search/impl/AuditLogSearchServlet.java
@@ -1,0 +1,157 @@
+/*
+ * #%L
+ * ACS AEM Tools Bundle
+ * %%
+ * Copyright (C) 2017 Dan Klco
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.tools.audit_log_search.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.query.Query;
+import javax.servlet.ServletException;
+
+import org.apache.felix.scr.annotations.sling.SlingServlet;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.commons.json.JSONArray;
+import org.apache.sling.commons.json.JSONException;
+import org.apache.sling.commons.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.acs.tools.audit_log_search.AuditLogSearchRequest;
+
+@SlingServlet(label = "ACS AEM Tools - Audit Log Search Servlet", methods = { "GET" }, resourceTypes = {
+		"acs-tools/components/audit-log-search" }, selectors = { "auditlogsearch" }, extensions = { "json" })
+public class AuditLogSearchServlet extends SlingSafeMethodsServlet {
+
+	private static final long serialVersionUID = 7661105540626580845L;
+
+	private static final Logger log = LoggerFactory.getLogger(AuditLogSearchServlet.class);
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.apache.sling.api.servlets.SlingSafeMethodsServlet#doGet(org.apache.
+	 * sling.api.SlingHttpServletRequest,
+	 * org.apache.sling.api.SlingHttpServletResponse)
+	 */
+	@Override
+	protected final void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
+			throws ServletException, IOException {
+
+		log.trace("doGet");
+
+		AuditLogSearchRequest req = null;
+		try {
+			JSONObject result = new JSONObject();
+			boolean succeeded = true;
+			try {
+				req = new AuditLogSearchRequest(request);
+				log.debug("Loaded search request: {}", req);
+
+				JSONArray results = new JSONArray();
+				long count = 0;
+				String query = "SELECT * FROM [cq:AuditEvent] AS s WHERE " + req.getQueryParameters();
+				log.debug("Finding audit events with: {}", query);
+				Iterator<Resource> auditEvents = request.getResourceResolver().findResources(query, Query.JCR_SQL2);
+				while (auditEvents.hasNext()) {
+					results.put(serializeAuditEvent(auditEvents.next(), req));
+					count++;
+				}
+				result.put("count", count);
+				result.put("events", results);
+				log.debug("Found {} audit events", count);
+			} catch (ParseException e) {
+				log.warn("Encountered exception parsing start / end date", e);
+				succeeded = false;
+			} catch (RepositoryException e) {
+				log.warn("Encountered respository exception attempting to retrieve audit events", e);
+				succeeded = false;
+			} catch (ClassNotFoundException e) {
+				log.warn("Encountered exception deserializing attributes", e);
+				succeeded = false;
+			}
+
+			result.put("succeeded", succeeded);
+
+			response.setContentType("application/json");
+			response.getWriter().write(result.toString());
+		} catch (JSONException e) {
+			throw new ServletException("Failed to serialize JSON", e);
+		}
+	}
+
+	private JSONObject serializeAuditEvent(Resource auditEventResource, AuditLogSearchRequest request)
+			throws JSONException, RepositoryException, IOException, ClassNotFoundException {
+		JSONObject auditEvent = new JSONObject();
+		ValueMap properties = auditEventResource.getValueMap();
+		auditEvent.put("category", properties.get("cq:category", String.class));
+		auditEvent.put("eventPath", auditEventResource.getPath());
+		auditEvent.put("path", properties.get("cq:path", String.class));
+		auditEvent.put("type", properties.get("cq:type", String.class));
+		String userId = properties.get("cq:userid", String.class);
+		auditEvent.put("userId", userId);
+		auditEvent.put("userName", request.getUserName(auditEventResource.getResourceResolver(), userId));
+		auditEvent.put("userPath", request.getUserPath(auditEventResource.getResourceResolver(), userId));
+		auditEvent.put("time", properties.get("cq:time", new Date()).getTime());
+		JSONArray modifiedProperties = getModifiedProperties(properties);
+		if (modifiedProperties != null && modifiedProperties.length() != 0) {
+			auditEvent.put("modifiedProperties", modifiedProperties);
+		}
+
+		return auditEvent;
+	}
+
+	@SuppressWarnings("unchecked")
+	private JSONArray getModifiedProperties(ValueMap properties) throws IOException {
+		JSONArray modifiedProperties = new JSONArray();
+		InputStream is = properties.get("cq:properties", InputStream.class);
+		if (is != null) {
+			ObjectInputStream ois = new ObjectInputStream(is);
+			ois.readInt();
+
+			while (ois.available() != -1) {
+				try {
+					Object obj = ois.readObject();
+					if (obj instanceof HashSet) {
+						Set<String> propertiesSet = (Set<String>) obj;
+						for (String property : propertiesSet) {
+							modifiedProperties.put(property);
+						}
+					}
+				} catch (Exception e) {
+					break;
+				}
+			}
+		}
+		return modifiedProperties;
+	}
+
+}

--- a/content/src/main/content/META-INF/vault/filter.xml
+++ b/content/src/main/content/META-INF/vault/filter.xml
@@ -6,4 +6,5 @@
     <filter root="/etc/acs-tools"/>
     <filter root="/etc/clientlibs/acs-tools"/>
     <filter root="/apps/cq/core/content/nav/tools/acs-tools"/>
+    <filter root="/oak:index/cqAuditEvent"/>
 </workspaceFilter>

--- a/content/src/main/content/META-INF/vault/filter.xml
+++ b/content/src/main/content/META-INF/vault/filter.xml
@@ -6,5 +6,5 @@
     <filter root="/etc/acs-tools"/>
     <filter root="/etc/clientlibs/acs-tools"/>
     <filter root="/apps/cq/core/content/nav/tools/acs-tools"/>
-    <filter root="/oak:index/cqAuditEvent" mode="merge" />
+    <filter root="/oak:index/cqAuditEvent" mode="merge"/>
 </workspaceFilter>

--- a/content/src/main/content/META-INF/vault/filter.xml
+++ b/content/src/main/content/META-INF/vault/filter.xml
@@ -6,5 +6,5 @@
     <filter root="/etc/acs-tools"/>
     <filter root="/etc/clientlibs/acs-tools"/>
     <filter root="/apps/cq/core/content/nav/tools/acs-tools"/>
-    <filter root="/oak:index/cqAuditEvent"/>
+    <filter root="/oak:index/cqAuditEvent" mode="merge" />
 </workspaceFilter>

--- a/content/src/main/content/jcr_root/_oak_index/.content.xml
+++ b/content/src/main/content/jcr_root/_oak_index/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:oak="http://jackrabbit.apache.org/oak/ns/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" jcr:primaryType="nt:unstructured">
+        <cqAuditEvent
+                jcr:primaryType="oak:QueryIndexDefinition"
+                declaringNodeTypes="{Name}[cq:AuditEvent]"
+                propertyNames="{Name}[cq:path,cq:type,cq:userid,cq:time]"
+                type="property"/>
+</jcr:root>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/.content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          cq:defaultView="html"
+          jcr:primaryType="cq:Component"
+          jcr:title="Audit Log Search"
+          sling:resourceSuperType="acs-tools/components/base-page"
+          favicon="/libs/wcm/core/content/misc.ico"
+          componentGroup=".hidden"/>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/clientlibs/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/clientlibs/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="acs-tools.audit-log-search.app"
+    dependencies="[coralui2,acs-tools.coralui2.angularjs,acs-tools.angularjs,acs-tools.json]"/>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/clientlibs/css.txt
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/clientlibs/css.txt
@@ -1,0 +1,3 @@
+#base=css
+
+app.css

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/clientlibs/css/app.css
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/clientlibs/css/app.css
@@ -1,0 +1,7 @@
+.audit-log-search-results{
+	overflow: auto;
+	max-height:500px;
+}
+.audit-log-search-results .coral-Table-row {
+	background-color: #ccc;
+}

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/clientlibs/js.txt
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/clientlibs/js.txt
@@ -1,0 +1,3 @@
+#base=js
+
+app.js

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/clientlibs/js/app.js
@@ -8,7 +8,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *	  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,53 +21,59 @@
 /*global angular: false, window: false */
 
 angular.module('acs-tools-audit-log-search-app', ['ACS.Tools.notifications', 'acsCoral']).config([
-    '$compileProvider',
-    function ($compileProvider) {
-        $compileProvider.aHrefSanitizationWhitelist(/^\s*((http):|(https):|(data):|(\/))/);
-    }
+	'$compileProvider',
+	function ($compileProvider) {
+		$compileProvider.aHrefSanitizationWhitelist(/^\s*((http):|(https):|(data):|(\/))/);
+	}
 
 ]).controller('MainCtrl',
-    ['$scope', '$http', 'NotificationsService', function ($scope, $http, NotificationsService) {
+	['$scope', '$http', 'NotificationsService', function ($scope, $http, NotificationsService) {
 
-        $scope.app = {
-            uri: ''
-        };
+		$scope.app = {
+			uri: ''
+		};
 
-        $scope.form = {
-            contentRoot: '',
-            includeChildren: 'true',
-            type: '',
-            user: '',
-            startDate: '',
-            endDate: '',
-            order: ''
-        };
+		$scope.form = {
+			contentRoot: '',
+			includeChildren: 'true',
+			type: '',
+			user: '',
+			startDate: '',
+			endDate: '',
+			order: '',
+			limit: 500
+		};
 
-        $scope.result = {};
+		$scope.result = {};
 
-        $scope.search = function () {
-            NotificationsService.running(true);
-            $scope.result = {};
-            $http({
-                method: 'GET',
-                url: $scope.app.uri+ '?contentRoot=' + encodeURIComponent($scope.form.contentRoot)
-                    + '&children=' + encodeURIComponent($scope.form.includeChildren)
-                    + '&type=' + encodeURIComponent($scope.form.type)
-                    + '&user=' + encodeURIComponent($scope.form.user)
-                    + '&startDate=' + encodeURIComponent($scope.form.startDate)
-                    + '&endDate=' + encodeURIComponent($scope.form.endDate)
-                    + '&order=' + encodeURIComponent($scope.form.order)
-            }).success(function (data, status, headers, config) {
-                $scope.result = data || {};
-                NotificationsService.running(false);
-                NotificationsService.add('success', 'SUCCESS', 'Found '+data.count+' audit events!');
+		$scope.search = function () {
+			var start = new Date().getTime();
+			NotificationsService.running(true);
+			$scope.result = {};
+			$http({
+				method: 'GET',
+				url: $scope.app.uri+ '?contentRoot=' + encodeURIComponent($scope.form.contentRoot)
+					+ '&children=' + encodeURIComponent($scope.form.includeChildren)
+					+ '&type=' + encodeURIComponent($scope.form.type)
+					+ '&user=' + encodeURIComponent($scope.form.user)
+					+ '&startDate=' + encodeURIComponent($scope.form.startDate)
+					+ '&endDate=' + encodeURIComponent($scope.form.endDate)
+					+ '&order=' + encodeURIComponent($scope.form.order)
+					+ '&limit=' + encodeURIComponent($scope.form.limit)
+			}).success(function (data, status, headers, config) {
 
-            }).error(function (data, status, headers, config) {
-                NotificationsService.running(false);
-                NotificationsService.add('error', 'ERROR', 'Unable to search audit logs!');
-            });
+				var time = new Date().getTime() - start;
+				data.time=time;
+				$scope.result = data || {};
+				NotificationsService.running(false);
+				NotificationsService.add('success', 'SUCCESS', 'Found '+data.count+' audit events in '+time+'ms!');
 
-        };
+			}).error(function (data, status, headers, config) {
+				NotificationsService.running(false);
+				NotificationsService.add('error', 'ERROR', 'Unable to search audit logs!');
+			});
 
-    }]);
+		};
+
+	}]);
 

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/clientlibs/js/app.js
@@ -1,0 +1,73 @@
+/*
+ * #%L
+ * ACS AEM Tools Package
+ * %%
+ * Copyright (C) 2014 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/*global angular: false, window: false */
+
+angular.module('acs-tools-audit-log-search-app', ['ACS.Tools.notifications', 'acsCoral']).config([
+    '$compileProvider',
+    function ($compileProvider) {
+        $compileProvider.aHrefSanitizationWhitelist(/^\s*((http):|(https):|(data):|(\/))/);
+    }
+
+]).controller('MainCtrl',
+    ['$scope', '$http', 'NotificationsService', function ($scope, $http, NotificationsService) {
+
+        $scope.app = {
+            uri: ''
+        };
+
+        $scope.form = {
+            contentRoot: '',
+            includeChildren: 'true',
+            type: '',
+            user: '',
+            startDate: '',
+            endDate: '',
+            order: ''
+        };
+
+        $scope.result = {};
+
+        $scope.search = function () {
+            NotificationsService.running(true);
+            $scope.result = {};
+            $http({
+                method: 'GET',
+                url: $scope.app.uri+ '?contentRoot=' + encodeURIComponent($scope.form.contentRoot)
+                    + '&children=' + encodeURIComponent($scope.form.includeChildren)
+                    + '&type=' + encodeURIComponent($scope.form.type)
+                    + '&user=' + encodeURIComponent($scope.form.user)
+                    + '&startDate=' + encodeURIComponent($scope.form.startDate)
+                    + '&endDate=' + encodeURIComponent($scope.form.endDate)
+                    + '&order=' + encodeURIComponent($scope.form.order)
+            }).success(function (data, status, headers, config) {
+                $scope.result = data || {};
+                NotificationsService.running(false);
+                NotificationsService.add('success', 'SUCCESS', 'Found '+data.count+' audit events!');
+
+            }).error(function (data, status, headers, config) {
+                NotificationsService.running(false);
+                NotificationsService.add('error', 'ERROR', 'Unable to search audit logs!');
+            });
+
+        };
+
+    }]);
+

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/clientlibs/js/app.js
@@ -1,8 +1,8 @@
 /*
  * #%L
- * ACS AEM Tools Package
+ * ACS AEM Tools Package - Audit Log Search
  * %%
- * Copyright (C) 2014 Adobe
+ * Copyright (C) 2017 Dan Klco
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/content.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/content.jsp
@@ -1,0 +1,26 @@
+<%--
+  #%L
+  ACS AEM Tools Package - Audit Log Search
+  %%
+  Copyright (C) 2017 Dan Klco
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  --%>
+<%@include file="/libs/foundation/global.jsp" %>
+<%@page session="false" %>
+<div ng-controller="MainCtrl" ng-init="app.uri = '${resourcePath}.auditlogsearch.json';">
+    <p>Explore the audit log at any path.</p>
+    <cq:include script="includes/form.jsp"/>
+    <cq:include script="includes/results.jsp"/>
+</div>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/includes/form.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/includes/form.jsp
@@ -1,0 +1,134 @@
+<%--
+  #%L
+  ACS AEM Tools Package - Audit Log Search
+  %%
+  Copyright (C) 2017 Dan Klco
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  --%>
+<%@include file="/libs/foundation/global.jsp" %><%@taglib prefix="sling2" uri="http://sling.apache.org/taglibs/sling" %>
+<form ng-submit="search()">
+	<div class="form-row">
+		<h4 acs-coral-heading>
+			Content Root
+		</h4>
+		<span>
+			<input type="text" name="contentRoot" class="coral-Textfield"  ng-required="true" ng-pattern="/^\/.+$/" ng-model="form.contentRoot" placeholder="Root path [ Default: /content ]"/>
+		</span>
+	</div>
+	
+	<div class="form-row">
+		<h4 acs-coral-heading>
+			Include Children?
+		</h4>
+		<div class="coral-Selector">
+			<label class="coral-Selector-option">
+				<input ng-model="form.includeChildren" type="radio" class="coral-Selector-input" name="includeChildren" value="true" />
+				<span class="coral-Selector-description">Yes</span>
+			</label>
+			<label class="coral-Selector-option">
+				<input ng-model="form.includeChildren" type="radio" class="coral-Selector-input" name="includeChildren" value="false" />
+				<span class="coral-Selector-description">No</span>
+			</label>
+		</div>
+	</div>
+	
+	<div class="form-row">
+		<h4 acs-coral-heading>
+			Event Type
+		</h4>
+		<span>
+			<input type="text" name="type" list="events" class="coral-Textfield" ng-model="form.type" placeholder="Event Type [ Optional, example: PageCreated ]"/>
+			<datalist id="events">
+				<option>Activate</option>
+				<option>ASSET_CREATED</option>
+				<option>ASSET_REMOVED</option>
+				<option>Deactivate</option>
+				<option>Delete</option>
+				<option>DOWNLOADED</option>
+				<option>PageCreated</option>
+				<option>PageDeleted</option>
+				<option>PageModified</option>
+				<option>PageMoved</option>
+				<option>VersionCreated</option>
+			</datalist>
+		</span>
+	</div>
+	
+	<div class="form-row">
+		<h4 acs-coral-heading>
+			Event User
+		</h4>
+		<span>
+			<input type="text" list="users" name="user" class="coral-Textfield" ng-model="form.user" placeholder="Event User [ Optional ]" />
+			<datalist id="users">
+				<c:forEach var="user" items="${sling2:findResources(resourceResolver,'SELECT * FROM [rep:User] AS s ORDER BY [profile/familyName], [profile/givenName]','JCR-SQL2')}">
+					<option value="${user.valueMap['rep:authorizableId']}">
+						<c:set var="profile" value="${sling2:getRelativeResource(user,'profile')}" />
+						<c:choose>
+							<c:when test="${profile != null && not empty profile.valueMap.givenName}">
+								<c:out value="${profile.valueMap.givenName}" /> <c:out value="${profile.valueMap.familyName}" />
+							</c:when>
+							<c:otherwise>
+								${user.valueMap['rep:authorizableId']}
+							</c:otherwise>
+						</c:choose>
+					</option>
+				</c:forEach>
+			</datalist>
+		</span>
+	</div>
+	
+	<div class="form-row">
+		<h4 acs-coral-heading>
+			Event Start Date
+		</h4>
+		<span>
+			<input type="datetime-local" name="startDate" class="coral-Textfield" ng-model="form.startDate" placeholder="Event Start Date [ Optional ]" />
+			<small>(UTC)</small>
+		</span>
+	</div>
+	
+	<div class="form-row">
+		<h4 acs-coral-heading>
+			Event End Date
+		</h4>
+		<span>
+			<input type="datetime-local" name="endDate" class="coral-Textfield" ng-model="form.endDate" placeholder="Event End Date [ Optional ]" />
+			<small>(UTC)</small>
+		</span>
+	</div>
+	
+	<div class="form-row">
+		<h4 acs-coral-heading>
+			Order By
+		</h4>
+		<span>
+			<input type="text" name="order" list="order" class="coral-Textfield" ng-model="form.order" placeholder="Order By [ Optional, [cq:time] ASC ]"/>
+			<datalist id="order">
+					<option value="[cq:time] ASC">Oldest</option>
+					<option value="[cq:time] DESC">Most Recent</option>
+					<option value="[cq:path] ASC">Content Path (Ascending)</option>
+					<option value="[cq:path] DESC">Content Path (Descending)</option>
+					<option value="[cq:userid] ASC">User ID (Ascending)</option>
+					<option value="[cq:userid] DESC">User ID (Descending)</option>
+			</datalist>
+		</span>
+	</div>
+	
+	<div class="form-row">
+		<div class="form-left-cell">&nbsp;</div>
+		<button class="coral-Button coral-Button--primary">Search Audit Log</button>
+	</div>
+</form>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/includes/form.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/includes/form.jsp
@@ -128,6 +128,15 @@
 	</div>
 	
 	<div class="form-row">
+		<h4 acs-coral-heading>
+			Limit
+		</h4>
+		<span>
+			<input type="number" name="limit" class="coral-Textfield" ng-model="form.limit" placeholder="Limit [ Optional, 10 ]"/>
+		</span>
+	</div>
+	
+	<div class="form-row">
 		<div class="form-left-cell">&nbsp;</div>
 		<button class="coral-Button coral-Button--primary">Search Audit Log</button>
 	</div>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/includes/results.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/includes/results.jsp
@@ -22,7 +22,7 @@
 com.day.cq.rewriter.linkchecker.LinkCheckerSettings.fromRequest(slingRequest).setIgnoreInternals(true);
 %>
 <div class="section">
-	<h2 acs-coral-heading>Audit Events</h2>
+	<h2 acs-coral-heading><span ng-show="result.count > 0">Found {{result.count}}</span> Audit Events <span ng-show="result.count > 0">in {{result.time}}ms</span></h2>
 </div>
 <div class="section audit-log-search-results" ng-show="result.count > 0">
 	<table class="coral-Table coral-Table--hover data">
@@ -52,14 +52,12 @@ com.day.cq.rewriter.linkchecker.LinkCheckerSettings.fromRequest(slingRequest).se
 				</a>
 			</td>
 			<td class="coral-Table-cell">
-				{{event.time | date:'yyyy-MM-dd HH:mm:ss Z'}}
+				{{event.time | date:'yyyy-MM-dd'}}&nbsp;{{event.time | date:'HH:mm:ss'}}&nbsp;{{event.time | date:'Z'}}
 			</td>
 			<td class="coral-Table-cell">
-				<ul>
-					<li ng-repeat="modifiedProperty in event.modifiedProperties">
+				<div ng-repeat="modifiedProperty in event.modifiedProperties">
 						{{modifiedProperty}}
-					</li>
-				</ul>
+				</div>
 			</td>
 			<td class="coral-Table-cell">
 				<a target="_blank" href="/crx/de/index.jsp{{'#'+event.eventPath}}" class="coral-Button coral-Button--square">

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/includes/results.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/audit-log-search/includes/results.jsp
@@ -1,0 +1,71 @@
+<%--
+  #%L
+  ACS AEM Tools Package - Audit Log Search
+  %%
+  Copyright (C) 2017 Dan Klco
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  --%>
+<%@include file="/libs/foundation/global.jsp" %>
+<%
+com.day.cq.rewriter.linkchecker.LinkCheckerSettings.fromRequest(slingRequest).setIgnoreInternals(true);
+%>
+<div class="section">
+	<h2 acs-coral-heading>Audit Events</h2>
+</div>
+<div class="section audit-log-search-results" ng-show="result.count > 0">
+	<table class="coral-Table coral-Table--hover data">
+	
+		<thead>
+			<tr class="coral-Table-row">
+				<th class="coral-Table-headerCell">Path</th>
+				<th class="coral-Table-headerCell">Type</th>
+				<th class="coral-Table-headerCell">User</th>
+				<th class="coral-Table-headerCell">Time</th>
+				<th class="coral-Table-headerCell">Modified Properties</th>
+				<th class="coral-Table-headerCell">CRXDE</th>
+			</tr>
+		</thead>
+		<tr ng-repeat="event in result.events" class="coral-Table-row">
+			<td class="coral-Table-cell">
+				<a target="_blank" href="/crx/de/index.jsp{{'#'+event.path}}" class="coral-Link">
+					{{event.path}}
+				</a>
+			</td>
+			<td class="coral-Table-cell">
+				{{event.type}}
+			</td>
+			<td class="coral-Table-cell">
+				<a class="coral-Link" target="_blank" href="/libs/granite/security/content/userEditor.html{{event.userPath }}">
+					{{ event.userName }} <small>({{ event.userId }})</small>
+				</a>
+			</td>
+			<td class="coral-Table-cell">
+				{{event.time | date:'yyyy-MM-dd HH:mm:ss Z'}}
+			</td>
+			<td class="coral-Table-cell">
+				<ul>
+					<li ng-repeat="modifiedProperty in event.modifiedProperties">
+						{{modifiedProperty}}
+					</li>
+				</ul>
+			</td>
+			<td class="coral-Table-cell">
+				<a target="_blank" href="/crx/de/index.jsp{{'#'+event.eventPath}}" class="coral-Button coral-Button--square">
+					<i class="coral-Icon coral-Icon--gear coral-Icon--sizeS"></i>
+				</a>
+			</td>
+		</tr>
+	</table>
+</div>

--- a/content/src/main/content/jcr_root/apps/cq/core/content/nav/tools/acs-tools/audit-log-search/.content.xml
+++ b/content/src/main/content/jcr_root/apps/cq/core/content/nav/tools/acs-tools/audit-log-search/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:description="Search the Audit Log"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Audit Log Search"
+    href="/etc/acs-tools/audit-log-search.html"
+    id="acs-tools-audit-log"
+    target="_blank"/>

--- a/content/src/main/content/jcr_root/etc/acs-tools/audit-log-search/.content.xml
+++ b/content/src/main/content/jcr_root/etc/acs-tools/audit-log-search/.content.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:lastModified="{Date}2013-11-26T11:28:23.253-05:00"
+        cq:lastModifiedBy="admin"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="Audit Log Search"
+        sling:resourceType="acs-tools/components/audit-log-search"/>
+</jcr:root>


### PR DESCRIPTION
So this is an itch I've wanted to scratch for awhile. It allows you to search for audit events based on:

- path (absolute or recursive)
- type
- user
- date/time

And then order & limit the events. I've defaulted it to limit to 500 results as this seems to have pretty acceptable performance against real data sources. It also parses out the updated properties, displays usernames and links to the user / page / event editor. 

There are a couple things which are a bit funky:

- I'm not 100% sure that the date/time searching is correct (e.g. timezones are a b**ch)
- This does require including an oak:index for `cq:AuditEvents`, otherwise it's abysmally slow

![screen shot 2017-02-10 at 4 53 47 pm](https://cloud.githubusercontent.com/assets/2946250/22845618/861a51d4-efb1-11e6-97e3-9c3490ee926d.png)
