### PR TITLE
#162 - Explicitly specify workspace name as workaround to JCRVLT-144

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
@@ -192,7 +192,7 @@ angular.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications'])
 
 
     $scope.reset = function() {
-        var taskSrc = 'http://admin:admin@localhost:4502/crx/server/-/jcr:root/content/dam/my-site',
+        var taskSrc = 'http://admin:admin@localhost:4502/crx/server/crx.default/jcr:root/content/dam/my-site',
             taskDst = '/content/dam/my-site',
             taskBatchSize = '1024',
             taskThrottle = '',

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
@@ -26,7 +26,7 @@ angular.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications'])
 
     $scope.rcp_uris = ['/system/jackrabbit/filevault/rcp', '/libs/granite/packaging/rcp'];
 
-    $scope.task_src = 'http://admin:admin@localhost:4502/crx/server/-/jcr:root/content/dam/my-site';
+    $scope.task_src = 'http://admin:admin@localhost:4502/crx/server/crx.default/jcr:root/content/dam/my-site';
 
     $scope.task_dst = '/content/dam/my-site';
 


### PR DESCRIPTION
Fixes #162 -- aligns temporary fix in https://issues.apache.org/jira/browse/JCRVLT-144 -- however the AEM use case only uses a single workspace, so this should be fine permanently.

With fix..

```
26.03.2017 22:15:58.217 *INFO* [Vault RCP Task - f5628b48-b9ec-4690-806b-95642bc952e1] org.apache.jackrabbit.vault.rcp.impl.RcpTask Starting repository copy task id=f5628b48-b9ec-4690-806b-95642bc952e1. From http://admin:admin@localhost:4502/crx/server/crx.default/jcr:root/content/dam/we-retail to /content/dam/test.
26.03.2017 22:15:58.684 *INFO* [Vault RCP Task - f5628b48-b9ec-4690-806b-95642bc952e1] org.apache.jackrabbit.vault.rcp.impl.RcpTask 000001 A /content/dam/test
26.03.2017 22:15:58.702 *INFO* [Vault RCP Task - f5628b48-b9ec-4690-806b-95642bc952e1] org.apache.jackrabbit.vault.rcp.impl.RcpTask 000002 A /content/dam/test/jcr:content
26.03.2017 22:15:58.703 *INFO* [Vault RCP Task - f5628b48-b9ec-4690-806b-95642bc952e1] org.apache.jackrabbit.vault.rcp.impl.RcpTask 000003 A /content/dam/test/jcr:content/folderThumbnail
26.03.2017 22:15:58.704 *INFO* [Vault RCP Task - f5628b48-b9ec-4690-806b-95642bc952e1] org.apache.jackrabbit.vault.rcp.impl.RcpTask 000004 A /content/dam/test/jcr:content/folderThumbnail/jcr:content
26.03.2017 22:15:58.712 *INFO* [Vault RCP Task - f5628b48-b9ec-4690-806b-95642bc952e1] org.apache.jackrabbit.vault.rcp.impl.RcpTask 000005 A /content/dam/test/en
26.03.201
```

without fix...

```
26.03.2017 22:12:43.915 *ERROR* [0:0:0:0:0:0:0:1 [1490580763888] POST /system/jackrabbit/filevault/rcp HTTP/1.1] org.apache.jackrabbit.vault.rcp.impl.RcpServlet Error while executing command start
javax.jcr.lock.LockException: Precondition Failed
	at org.apache.jackrabbit.spi2dav.ExceptionConverter.generate(ExceptionConverter.java:109)
	at org.apache.jackrabbit.spi2dav.ExceptionConverter.generate(ExceptionConverter.java:51)
	at org.apache.jackrabbit.spi2dav.ExceptionConverter.generate(ExceptionConverter.java:45)
	at org.apache.jackrabbit.spi2dav.RepositoryServiceImpl.obtain(RepositoryServiceImpl.java:809)
	at org.apache.jackrabbit.spi2dav.RepositoryServiceImpl.obtain(RepositoryServiceImpl.java:753)
	at org.apache.jackrabbit.spi2davex.RepositoryServiceImpl.obtain(RepositoryServiceImpl.java:307)
	at org.apache.jackrabbit.jcr2spi.RepositoryImpl.login(RepositoryImpl.java:151)
	at org.apache.jackrabbit.commons.AbstractRepository.login(AbstractRepository.java:144)
	at org.apache.jackrabbit.vault.rcp.impl.RcpTask.getSourceSession(RcpTask.java:184)
	at org.apache.jackrabbit.vault.rcp.impl.RcpTask.start(RcpTask.java:160)
	at org.apache.jackrabbit.vault.rcp.impl.RcpServlet.doPost(RcpServlet.java:164)
	at org.apache.sling.api.servlets.SlingAllMethodsServlet.mayService(SlingAllMethodsServlet.java:149)
	at org.apache.sling.api.servlets.SlingSafeMethodsServlet.service(SlingSafeMethodsServlet.java:346)
	at org.apache.sling.api.servlets.SlingSafeMethodsServlet.service(SlingSafeMethodsServlet.java:378)
	at org.apache.sling.engine.impl.request.RequestData.service(RequestData.java:552)
	at org.apache.sling.engine.impl.filter.SlingComponentFilterChain.render(SlingComponentFilterChain.java:44)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:77)
	at com.day.cq.wcm.core.impl.WCMDebugFilter.doFilter(WCMDebugFilter.java:156)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.day.cq.wcm.core.impl.WCMComponentFilter.filterRootInclude(WCMComponentFilter.java:375)
	at com.day.cq.wcm.core.impl.WCMComponentFilter.doFilter(WCMComponentFilter.java:190)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.day.cq.personalization.impl.TargetComponentFilter.doFilter(TargetComponentFilter.java:96)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at org.apache.sling.engine.impl.SlingRequestProcessorImpl.processComponent(SlingRequestProcessorImpl.java:282)
	at org.apache.sling.engine.impl.filter.RequestSlingFilterChain.render(RequestSlingFilterChain.java:49)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:71)
	at com.adobe.cq.social.ugcbase.security.impl.SaferSlingPostServlet.doFilter(SaferSlingPostServlet.java:126)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.day.cq.dam.core.impl.assetlinkshare.AdhocAssetShareAuthHandler.doFilter(AdhocAssetShareAuthHandler.java:436)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.day.cq.dam.core.impl.servlet.ActivityRecordHandler.doFilter(ActivityRecordHandler.java:154)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:73)
	at com.adobe.granite.rest.impl.servlet.ApiResourceFilter.doFilter(ApiResourceFilter.java:70)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.adobe.granite.requests.logging.impl.RequestLoggerImpl.doFilter(RequestLoggerImpl.java:113)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.adobe.granite.rest.assets.impl.AssetContentDispositionFilter.doFilter(AssetContentDispositionFilter.java:96)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.adobe.granite.csrf.impl.CSRFFilter.doFilter(CSRFFilter.java:217)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at org.apache.sling.security.impl.ContentDispositionFilter.doFilter(ContentDispositionFilter.java:180)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.day.cq.wcm.core.impl.AuthoringUIModeServiceImpl.doFilter(AuthoringUIModeServiceImpl.java:292)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.day.cq.wcm.mobile.core.impl.redirect.RedirectFilter.doFilter(RedirectFilter.java:248)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at org.apache.sling.engine.impl.debug.RequestProgressTrackerLogFilter.doFilter(RequestProgressTrackerLogFilter.java:107)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.adobe.cq.social.commons.cors.CORSAuthenticationFilter.doFilter(CORSAuthenticationFilter.java:91)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.day.cq.wcm.foundation.forms.FormsHandlingServletHelper.handleFilter(FormsHandlingServletHelper.java:221)
	at com.day.cq.wcm.foundation.forms.impl.FormsHandlingServlet.doFilter(FormsHandlingServlet.java:138)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.adobe.granite.optout.impl.OptOutFilter.doFilter(OptOutFilter.java:76)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.day.cq.wcm.foundation.forms.FormsHandlingServletHelper.handleFilter(FormsHandlingServletHelper.java:221)
	at com.adobe.cq.wcm.core.components.internal.servlets.CoreFormHandlingServlet.doFilter(CoreFormHandlingServlet.java:131)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.day.cq.wcm.core.impl.WCMRequestFilter.doFilter(WCMRequestFilter.java:90)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.adobe.cq.mcm.campaign.servlets.CampaignCopyTracker.doFilter(CampaignCopyTracker.java:100)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at org.apache.sling.rewriter.impl.RewriterFilter.doFilter(RewriterFilter.java:83)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at com.adobe.granite.httpcache.impl.InnerCacheFilter.doFilter(InnerCacheFilter.java:81)
	at com.adobe.granite.httpcache.impl.InnerCacheFilter.doFilter(InnerCacheFilter.java:60)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at org.apache.sling.i18n.impl.I18NFilter.doFilter(I18NFilter.java:138)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:73)
	at com.adobe.granite.resourceresolverhelper.impl.ResourceResolverHelperImpl.doFilter(ResourceResolverHelperImpl.java:83)
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:68)
	at org.apache.sling.engine.impl.SlingRequestProcessorImpl.doProcessRequest(SlingRequestProcessorImpl.java:151)
	at org.apache.sling.engine.impl.SlingMainServlet.service(SlingMainServlet.java:219)
	at org.apache.felix.http.base.internal.handler.ServletHandler.handle(ServletHandler.java:85)
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:79)
	at org.apache.sling.security.impl.ReferrerFilter.doFilter(ReferrerFilter.java:295)
	at org.apache.felix.http.base.internal.handler.FilterHandler.handle(FilterHandler.java:135)
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:74)
	at com.adobe.granite.license.impl.LicenseCheckFilter.doFilter(LicenseCheckFilter.java:308)
	at org.apache.felix.http.base.internal.handler.FilterHandler.handle(FilterHandler.java:135)
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:74)
	at org.apache.felix.http.sslfilter.internal.SslFilter.doFilter(SslFilter.java:96)
	at org.apache.felix.http.base.internal.handler.FilterHandler.handle(FilterHandler.java:135)
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:74)
	at org.apache.sling.i18n.impl.I18NFilter.doFilter(I18NFilter.java:138)
	at org.apache.felix.http.base.internal.handler.FilterHandler.handle(FilterHandler.java:135)
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:74)
	at org.apache.sling.featureflags.impl.FeatureManager.doFilter(FeatureManager.java:116)
	at org.apache.felix.http.base.internal.handler.FilterHandler.handle(FilterHandler.java:135)
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:74)
	at org.apache.sling.engine.impl.log.RequestLoggerFilter.doFilter(RequestLoggerFilter.java:72)
	at org.apache.felix.http.base.internal.handler.FilterHandler.handle(FilterHandler.java:135)
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:74)
	at org.apache.felix.http.base.internal.dispatch.Dispatcher.dispatch(Dispatcher.java:128)
	at org.apache.felix.http.base.internal.dispatch.DispatcherServlet.service(DispatcherServlet.java:49)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:725)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:812)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:587)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:221)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1127)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:515)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1061)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:215)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
	at org.eclipse.jetty.server.Server.handle(Server.java:499)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:311)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:257)
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:544)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.apache.jackrabbit.webdav.DavException: Precondition Failed
	at org.apache.jackrabbit.webdav.client.methods.DavMethodBase.getResponseException(DavMethodBase.java:163)
	at org.apache.jackrabbit.webdav.client.methods.DavMethodBase.getResponseBodyAsMultiStatus(DavMethodBase.java:92)
	at org.apache.jackrabbit.spi2dav.RepositoryServiceImpl.obtain(RepositoryServiceImpl.java:781)
	... 112 common frames omitted
```