### PR TITLE
CSV Asset Importer - Ability to upload Assets along with the metadata in a zip file from a remote system.

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/tools/csv_asset_importer/impl/CsvAssetImporterServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/csv_asset_importer/impl/CsvAssetImporterServlet.java
@@ -37,10 +37,7 @@ import org.apache.jackrabbit.commons.JcrUtils;
 import org.apache.jackrabbit.util.Text;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
-import org.apache.sling.api.resource.PersistenceException;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.resource.*;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.commons.json.JSONException;
 import org.apache.sling.commons.json.JSONObject;
@@ -314,6 +311,24 @@ public class CsvAssetImporterServlet extends SlingAllMethodsServlet {
                 }
             }
         }
+    }
+
+    /**
+     * Updates AEM System properties of the Asset.
+     * @param asset the asset to update.
+     */
+    private void updateSystemProperties(final Asset asset) {
+        Resource resource = asset.adaptTo(Resource.class);
+        Resource jcrContentResource = resource.getChild(JcrConstants.JCR_CONTENT);
+        if (jcrContentResource == null) {
+            log.error("Could not find the jcr:content node for asset [ {} ]", asset.getPath());
+            return;
+        }
+
+        final ModifiableValueMap properties = jcrContentResource.adaptTo(ModifiableValueMap.class);
+
+        properties.put("cq:name", asset.getName());
+        properties.put("cq:parentPath", StringUtils.removeEnd(asset.getPath(), "/" + asset.getName()));
     }
 
     /**


### PR DESCRIPTION
Hi,

At present the CSV importer doesn't support bulk asset upload from a system other than the one on which AEM instance is running.

We have been receiving many requests from the customers for enabling their respective business teams to do bulk upload of images in an archive format along with the metadata.

We have made some enhancements to the CSV importer tool to incorporate the aforesaid feature.

Kindly allow me to commit the changes.

Regards,
Namit