### PR TITLE
Add a dependency to the cq-content bundle

### DIFF
--- a/content/pom.xml
+++ b/content/pom.xml
@@ -61,6 +61,13 @@
                             <target>/apps/acs-tools/install</target>
                         </embedded>
                     </embeddeds>
+                    <dependencies>
+                        <dependency>
+                            <group>day/cq60/product</group>
+                            <name>cq-content</name>
+                            <version>[6.3.64,)</version>
+                        </dependency>
+                    </dependencies>
                     <targetURL>http://${crx.host}:${crx.port}/crx/packmgr/service.jsp</targetURL>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Add a dependency to the cq-content bundle as to make sure the primary… types are available before actually installing this bundle

fixes #197 