### PR TITLE
Defect when the same name of a property index exists twice in the query

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -63,7 +63,7 @@
                 <artifactId>maven-sling-plugin</artifactId>
                 <configuration>
                     <slingUrl>http://${crx.host}:${crx.port}/apps/acs-tools/install</slingUrl>
-                    <usePut>true</usePut>
+                    <deploymentMethod>SlingPostServlet</deploymentMethod>
                 </configuration>
             </plugin>
             <plugin>

--- a/bundle/src/main/java/com/adobe/acs/tools/explain_query/impl/ExplainQueryServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/tools/explain_query/impl/ExplainQueryServlet.java
@@ -69,13 +69,7 @@ import javax.management.openmbean.CompositeData;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -278,27 +272,27 @@ public class ExplainQueryServlet extends SlingAllMethodsServlet {
         final String plan = firstRow.getValue("plan").getString();
         json.put("plan", plan);
 
-        final JSONArray propertyIndexes = new JSONArray();
+        final Set<String> propertyIndexes = new HashSet<String>();
 
         final Matcher propertyMatcher = PROPERTY_INDEX_PATTERN.matcher(plan);
         /* Property Index */
         while (propertyMatcher.find()) {
             final String match = propertyMatcher.group(1);
             if (StringUtils.isNotBlank(match)) {
-                propertyIndexes.put(StringUtils.stripToEmpty(match));
+                propertyIndexes.add(StringUtils.stripToEmpty(match));
             }
         }
 
-        if (propertyIndexes.length() > 0) {
-            json.put("propertyIndexes", propertyIndexes);
+        if (!propertyIndexes.isEmpty()) {
+            json.put("propertyIndexes", new JSONArray().put(propertyIndexes));
         }
 
         final Matcher filterMatcher = FILTER_PATTERN.matcher(plan);
         if (filterMatcher.find()) {
             /* Filter (nodeType index) */
 
-            propertyIndexes.put("nodeType");
-            json.put("propertyIndexes", propertyIndexes);
+            propertyIndexes.add("nodeType");
+            json.put("propertyIndexes", new JSONArray().put(propertyIndexes));
             json.put("slow", true);
         }
 

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/explain-query/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/explain-query/clientlibs/js/app.js
@@ -67,7 +67,7 @@ angular.module('acs-tools-explain-query-app', ['ACS.Tools.notifications', 'acsCo
                 success(function (data, status, headers, config) {
                     $scope.result = data || {};
                     NotificationsService.running(false);
-                    NotificationsService.ad('success', 'SUCCESS', 'Review your query explanation');
+                    NotificationsService.add('success', 'SUCCESS', 'Review your query explanation');
 
                 }).
                 error(function (data, status, headers, config) {

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/explain-query/includes/explanation.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/explain-query/includes/explanation.jsp
@@ -48,8 +48,7 @@
          ng-show="result.explain.propertyIndexes || result.explain.traversal">
         <div ng-show="result.explain.propertyIndexes">
             Oak indexes used:
-            <span
-                    ng-repeat="propertyIndex in result.explain.propertyIndexes">{{propertyIndex}}{{$last ? '' : ', '}}</span>
+            <span ng-repeat="propertyIndex in result.explain.propertyIndexes track by $index">{{propertyIndex}}{{$last ? '' : ', '}}</span>
         </div>
 
         <div ng-show="result.explain.traversal">

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
                 <plugin>
                     <groupId>org.apache.sling</groupId>
                     <artifactId>maven-sling-plugin</artifactId>
-                    <version>2.1.0</version>
+                    <version>2.1.8</version>
                 </plugin>
                 <plugin>
                     <groupId>com.day.jcr.vault</groupId>


### PR DESCRIPTION
Hey guys,

There is a bug in the explain query when the same name of property index exists twice => This can happen when the query is a union of two queries and for example the union both have property sling:resourceType in their query

I also fixed a typo which threw exceptions, making the success message not show

Lastly I updated to the lastest sling-plugin because it works better when intermediate paths don't exist