### PR TITLE
defect/Fix 'tools' node's primary type

### DIFF
--- a/content/src/main/content/jcr_root/apps/cq/core/content/nav/tools/.content.xml
+++ b/content/src/main/content/jcr_root/apps/cq/core/content/nav/tools/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="nt:unstructured"/>


### PR DESCRIPTION
This PR is to fix the 'tools' node to match the OOTB 'tools' node. Currently, it is being created with a primary type of 'nt:folder' when it should be created with a primary type of 'nt:unstructured'. 