### PR TITLE
VLT-RCP: Duplicate functionality and UI enhancements

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/css/style.less
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/css/style.less
@@ -37,13 +37,18 @@
     .coral-Accordion-item {
       border: 1px #dfdfdf solid;
       .coral-Accordion-header {
-        height: 2.5rem;
+        height: auto;
+
         > i {
           min-width: 18px;
         }
         .task-actions {
           float: right;
-          margin-right: 3em;
+          margin-right: 0;
+          > button {
+            padding-left: 0;
+            padding-right: 0;
+          }
         }
         .coral-Accordion-title {
           font-size: 1.125rem

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/css/style.less
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/css/style.less
@@ -35,6 +35,9 @@
         margin: 10px auto;
       }
     }
+    .no-padding {
+      padding: 0;
+    }
   }
 
   .top-button-group {
@@ -52,18 +55,19 @@
 
 #create-new-task-modal {
 
-  width: 80%;
-  margin-bottom: 50px;
-  position: absolute;
+  .coral-Modal-body {
+    padding-left: 6em;
+    padding-right: 6em;
+  }
 
   input[type=text], input[type=password] {
-      width: 75%;
+      width: 100%;
   }
   
   .excludes {
-      width: 75%;
+      width: 100%;
       input[type=text] {
-          width: 80%;
+          width: 90%;
       }
   }
 

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/css/style.less
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/css/style.less
@@ -23,20 +23,41 @@
   .tasks {
     width: 100%;
     margin-bottom: 50px;
-
-    td {
-      text-align: left;
-      vertical-align: top;
+    .coral-Accordion-item {
+      opacity: 1;
     }
-
-    td.actions {
-      text-align: center;
-      .action-button {
-        margin: 10px auto;
+    .coral-Accordion-item.ng-enter {
+      -webkit-transition: 1s;
+      transition: 1s;
+      opacity: 0;
+    }
+    .coral-Accordion-item.ng-enter-active {
+      opacity: 1;
+    }
+    .coral-Accordion-item {
+      border: 1px #dfdfdf solid;
+      .coral-Accordion-header {
+        height: 2.5rem;
+        > i {
+          min-width: 18px;
+        }
+        .task-actions {
+          float: right;
+          margin-right: 3em;
+        }
+        .coral-Accordion-title {
+          font-size: 1.125rem
+        }
       }
-    }
-    .no-padding {
-      padding: 0;
+      .coral-Accordion-content {
+        .task-status, .task-settings {
+          ul {
+            list-style: none;
+            padding: 0;
+            margin-left: 1em;
+          }
+        }
+      }
     }
   }
 
@@ -54,7 +75,10 @@
 }
 
 #create-new-task-modal {
-
+  width: 80%;
+  position: absolute;
+  top: 0 !important; // for some reason, the CUI modal has negative top value
+  margin-top: 0 !important; // for some reason, the CUI modal has negative margin value
   .coral-Modal-body {
     padding-left: 6em;
     padding-right: 6em;

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/css/style.less
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/css/style.less
@@ -42,13 +42,21 @@
   }
 }
 
+.auto-refresh-section {
+  .auto-refresh-label {
+    .auto-refresh-text {
+      margin-left: .3125rem;
+    }
+  }
+}
+
 #create-new-task-modal {
 
   width: 80%;
   margin-bottom: 50px;
   position: absolute;
 
-  input[type=text] {
+  input[type=text], input[type=password] {
       width: 75%;
   }
   

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
@@ -18,10 +18,10 @@
  * #L%
  */
 
-/*global angular: false */
+/*global angular,CUI: false */
 
 angular
-.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications'])
+.module('acs-tools-vlt-rcp-app', ['ngAnimate','acsCoral', 'ACS.Tools.notifications'])
 .controller('MainCtrl', ['$scope', '$http', '$timeout', '$interval', 'NotificationsService',
 function ($scope, $http, $timeout, $interval, NotificationsService) {
 
@@ -54,6 +54,8 @@ function ($scope, $http, $timeout, $interval, NotificationsService) {
 
     $scope.vltMissing = true;
 
+    $scope.taskExpandedStatuses = [];
+
     /*
     * Loads the tasks
     */
@@ -80,18 +82,21 @@ function ($scope, $http, $timeout, $interval, NotificationsService) {
         });
     };
 
+    /**
+     * Refresh tasks
+     */
     $scope.refresh = function () {
         $http.get($scope.app.uri,
             {
                 params: {ck: (new Date()).getTime()}
             }
-        ).
-            success(function (data, status, headers, config) {
-                $scope.tasks = data.tasks || [];
-            })
-            .error(function (data, status, headers, config) {
-                NotificationsService.add('error', 'ERROR', 'Could not refresh tasks');
-            });
+        )
+        .success(function (data, status, headers, config) {
+            $scope.tasks = data.tasks || [];
+        })
+        .error(function (data, status, headers, config) {
+            NotificationsService.add('error', 'ERROR', 'Could not refresh tasks');
+        });
     };
 
     /**
@@ -139,7 +144,7 @@ function ($scope, $http, $timeout, $interval, NotificationsService) {
                 $scope.refresh();
             }).
             error(function (data, status, headers, config) {
-                NotificationsService.add('error', 'ERROR', 'Could not retrieve tasks');
+                NotificationsService.add('error', 'ERROR', 'Error while starting task: '+task.id+'. Please check logs');
             });
     };
 
@@ -181,6 +186,9 @@ function ($scope, $http, $timeout, $interval, NotificationsService) {
             });
     };
 
+    /**
+     * Create new task
+     */
     $scope.create = function () {
         var i = 0,
             cmd = {
@@ -206,17 +214,18 @@ function ($scope, $http, $timeout, $interval, NotificationsService) {
             });
         }
 
-        $http.post($scope.app.uri, cmd).
-            success(function (data, status, headers, config) {
-                NotificationsService.add('info', 'INFO', 'Task created.');
+        $http
+        .post($scope.app.uri, cmd)
+        .success(function (data, status, headers, config) {
+            NotificationsService.add('info', 'INFO', 'Task created.');
 
-                $scope.refresh();
-                angular.element('#create-new-task-modal').modal('hide');
-                $scope.reset();
-            }).
-            error(function (data, status, headers, config) {
-                NotificationsService.add('error', 'ERROR', data.message);
-            });
+            $scope.refresh();
+            angular.element('#create-new-task-modal').modal('hide');
+            $scope.reset();
+        })
+        .error(function (data, status, headers, config) {
+            NotificationsService.add('error', 'ERROR', data.message);
+        });
     };
 
 

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
@@ -183,7 +183,6 @@ function ($scope, $http, $timeout, $interval, NotificationsService) {
 
     $scope.create = function () {
         var i = 0,
-            excludes = [],
             cmd = {
                 "cmd": "create",
                 "id": $scope.task_id,
@@ -202,10 +201,9 @@ function ($scope, $http, $timeout, $interval, NotificationsService) {
         }
 
         if ($scope.excludes.length > 0) {
-            for (; i < $scope.excludes.length; i++) {
-                excludes.push($scope.excludes[i].value);
-            }
-            cmd.excludes = excludes;
+            cmd.excludes = $scope.excludes.map(function(exclude){
+                return exclude.value;
+            });
         }
 
         $http.post($scope.app.uri, cmd).
@@ -223,24 +221,18 @@ function ($scope, $http, $timeout, $interval, NotificationsService) {
 
 
     $scope.reset = function() {
-        var taskSrc = 'http://localhost:4502/crx/server/crx.default/jcr:root/content/dam/my-site',
-            taskDst = '/content/dam/my-site',
-            taskBatchSize = '1024',
-            taskThrottle = '',
-            checkboxModel = {
-                recursive: false,
-                update: false,
-                onlyNewer: false,
-                noOrdering: false,
-                autoRefresh: false
-            };
-
         $scope.task_id = '';
-        $scope.task_src = taskSrc;
-        $scope.task_dst = taskDst;
-        $scope.task_batchSize = taskBatchSize;
-        $scope.task_throttle = taskThrottle;
-        $scope.checkboxModel = checkboxModel;
+        $scope.task_src = 'http://localhost:4502/crx/server/crx.default/jcr:root/content/dam/my-site';
+        $scope.task_dst = '/content/dam/my-site';
+        $scope.task_batchSize = '1024';
+        $scope.task_throttle = '';
+        $scope.checkboxModel = {
+            recursive: false,
+            update: false,
+            onlyNewer: false,
+            noOrdering: false,
+            autoRefresh: false
+        };
         $scope.excludes = [];
     };
 

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
@@ -20,9 +20,10 @@
 
 /*global angular: false */
 
-angular.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications']).controller('MainCtrl',
-    [ '$scope', '$http', '$timeout', '$interval', 'NotificationsService',
-        function ($scope, $http, $timeout, $interval, NotificationsService) {
+angular
+.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications'])
+.controller('MainCtrl', ['$scope', '$http', '$timeout', '$interval', 'NotificationsService',
+function ($scope, $http, $timeout, $interval, NotificationsService) {
 
     $scope.rcp_uris = ['/system/jackrabbit/filevault/rcp', '/libs/granite/packaging/rcp'];
 
@@ -54,8 +55,8 @@ angular.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications'])
     $scope.vltMissing = true;
 
     /*
-     * Loads the tasks
-     */
+    * Loads the tasks
+    */
     $scope.init = function (rcpUris) {
 
         $scope.rcp_uris = rcpUris || $scope.rcp_uris;
@@ -94,8 +95,8 @@ angular.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications'])
     };
 
     /*
-     * Start task
-     */
+    * Start task
+    */
     $scope.start = function (task) {
         var cmd = {
             "cmd": "start",
@@ -113,8 +114,8 @@ angular.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications'])
     };
 
     /*
-     * Stop task
-     */
+    * Stop task
+    */
     $scope.stop = function (task) {
         var cmd = {
             "cmd": "stop",
@@ -132,8 +133,8 @@ angular.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications'])
     };
 
     /*
-     * Remove task
-     */
+    * Remove task
+    */
     $scope.remove = function (task) {
         var cmd = {
             "cmd": "remove",
@@ -227,16 +228,17 @@ angular.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications'])
         }
     }, 5000);
 
-}]).filter('removeCredentials', function() {
+}])
+.filter('removeCredentials', function() {
     return function(input) {
         /*
         The regex causes jslint error
-         You can 'fix' the warning by telling JSLint to ignore it: add regexp: true to your JSLint settings at the top of the file.
-         http://stackoverflow.com/questions/10793814/how-to-rectify-insecure-error-in-jslint
-         */
+        You can 'fix' the warning by telling JSLint to ignore it: add regexp: true to your JSLint settings at the top of the file.
+        http://stackoverflow.com/questions/10793814/how-to-rectify-insecure-error-in-jslint
+        */
         var segments = input.match(/(\bhttps?:\/\/[\S]+:)([\S]+)(@\S*)/);
         if (segments && segments.length === 4) {
-           return segments[1] + '******' + segments[3];
+        return segments[1] + '******' + segments[3];
         } else {
             return input;
         }

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
@@ -94,6 +94,36 @@ function ($scope, $http, $timeout, $interval, NotificationsService) {
             });
     };
 
+    /**
+     * Set the scope values from a task
+     * Used for the duplicate functionality
+     * @param {*} task The task to duplicate
+     */
+    $scope.duplicate = function (task) {
+        $scope.task_id = task.id + "-copy"; // unique
+        $scope.task_src = task.src;
+        $scope.task_dst = task.dst;
+        $scope.task_batchSize = task.batchsize;
+        $scope.task_throttle = task.throttle;
+        $scope.checkboxModel = {
+            recursive: task.recursive,
+            update: task.update,
+            onlyNewer: task.onlyNewer,
+            noOrdering: task.noOrdering,
+            autoRefresh: false
+        };
+
+        if (task.excludes) {
+            $scope.excludes = task.excludes.map(function(exclude){
+                return {value: exclude};
+            });
+        }
+
+        if (task.resumeFrom) {
+            $scope.task_resumeFrom = task.resumeFrom;
+        }
+    };
+
     /*
     * Start task
     */

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
@@ -158,7 +158,7 @@ function ($scope, $http, $timeout, $interval, NotificationsService) {
                 "cmd": "create",
                 "id": $scope.task_id,
                 "src": $scope.task_src,
-                "srcCreds": $scope.task_src_credentials,
+                "srcCreds": $scope.task_src_username + ":" + $scope.task_src_password,
                 "dst": $scope.task_dst,
                 "batchsize": $scope.task_batchSize || 1024,
                 "update": $scope.checkboxModel.update,

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
@@ -235,7 +235,7 @@ angular.module('acs-tools-vlt-rcp-app', ['acsCoral', 'ACS.Tools.notifications'])
          http://stackoverflow.com/questions/10793814/how-to-rectify-insecure-error-in-jslint
          */
         var segments = input.match(/(\bhttps?:\/\/[\S]+:)([\S]+)(@\S*)/);
-        if (segments.length === 4) {
+        if (segments && segments.length === 4) {
            return segments[1] + '******' + segments[3];
         } else {
             return input;

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/clientlibs/js/app.js
@@ -275,4 +275,18 @@ function ($scope, $http, $timeout, $interval, NotificationsService) {
         }
         /* jshint ignore:end */
     };
+})
+.filter('truncate', function() {
+    return function(input, limit) {
+        input = input || '';
+
+        if(input.length < limit) {
+            return input;
+        } else {
+            var half = limit / 2,
+                left = input.substring(0, half),
+                right = input.substring(input.length - half, input.length);
+            return left + '...' + right; 
+        }
+    };
 });

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/content.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/content.jsp
@@ -61,8 +61,9 @@
             <div class="coral-Selector">
                 <label class="coral-Selector-option auto-refresh-label">
                     <input class="coral-Selector-input" type="checkbox" ng-model="checkboxModel.autoRefresh">
-                    <span class="coral-Selector-description">
-                        <i class="coral-Icon coral-Icon--refresh coral-Selector-icon"></i>Auto Refresh
+                    <span class="coral-Selector-description auto-refresh-description">
+                        <i class="coral-Icon coral-Icon--refresh coral-Selector-icon"></i>
+                        <span class="auto-refresh-text">Auto Refresh</span>
                     </span>
                 </label>
             </div>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/content.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/content.jsp
@@ -121,7 +121,7 @@
                             <div>{{ task.status.state }}</div>
                             <div ng-show="task.expanded">
 
-                                <ul>
+                                <ul class="no-padding">
                                     <li>Current path: {{ task.status.currentPath || 'N/A' }}</li>
                                     <li>Last saved path:
                                         {{ task.status.lastSavedPath || 'N/A' }}</li>
@@ -133,13 +133,13 @@
                             </div>
                         </td>
                         <td class="coral-Table-cell">
-                            <ul>
+                            <ul class="no-padding">
                                 <li>Source: {{ task.src | removeCredentials
                                     }}</li>
                                 <li>Destination: {{ task.dst }}</li>
                             </ul>
 
-                            <ul ng-show="task.expanded">
+                            <ul ng-show="task.expanded" class="no-padding">
                                 <li>Recursive: {{ task.recursive }}</li>
                                 <li>Batch size: {{ task.batchsize }}</li>
                                 <li>Update: {{ task.update }}</li>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/content.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/content.jsp
@@ -29,7 +29,7 @@
 %><div  ng-controller="MainCtrl"
         ng-init="init(['${rcpPath}', '${legacyRcpPath}']);">
 
-    <%-- VLT-RCP Not installed --%>
+    <!-- VLT-RCP Not installed Message -->
     <div ng-show="vltMissing">
         <div acs-coral-alert data-alert-type="error" data-alert-size="large"
             data-alert-title="VLT-RCP servlet missing, inactive or unreachable">
@@ -54,9 +54,12 @@
                 </ol>
         </div>
     </div>
+    <!-- // VLT-RCP Not installed Message -->
+
 
     <div ng-show="!vltMissing" class="auto-refresh-section">
-
+        
+        <!-- Header buttons: add/refresh -->
         <div class="coral-ButtonGroup top-button-group">
             <div class="coral-Selector">
                 <label class="coral-Selector-option auto-refresh-label">
@@ -72,82 +75,97 @@
                     data-target="#create-new-task-modal"
                     data-toggle="modal"><i class="icon-add"></i> Add Task</button>
         </div>
+        <!-- // Header buttons: add/refresh -->
 
-        <%-- No Tasks Defined --%>
+        <!-- No tasks defined message -->
         <div class="section" ng-show="tasks.length == 0">
-
-            <%-- No Tasks Defined --%>
             <div acs-coral-alert data-alert-type="notice" data-alert-size="large"
                  data-alert-title="No tasks defined" data-dismissible="false">
                     No VLT-RCP tasks have been defined.
-
                     <ul>
                         <li><a href="#"
-                                 data-target="#create-new-task-modal"
-                                 data-toggle="modal">Create a new VLT-RCP task.</a></li>
+                               data-target="#create-new-task-modal"
+                               data-toggle="modal">Create a new VLT-RCP task.</a>
+                        </li>
                     </ul>
-
             </div>
-
         </div>
+        <!-- // No tasks defined message -->
 
-        <%-- Tasks Defined --%>
+        <!-- Tasks accordion section -->
         <div class="section" ng-show="tasks.length > 0">
 
             <h2 acs-coral-heading>Current Tasks</h2>
-
             <p>
-                Click on the <i class="coral-Icon coral-Icon--treeExpand"></i> to view the details for each Task.
+                Click on the <i class="coral-Icon coral-Icon--duplicate"></i> icon to create a new task with duplicate values.
             </p>
 
-            <table class="coral-Table data tasks">
-                <thead>
-                    <tr class="coral-Table-row">
-                        <th class="coral-Table-headerCell">Task Id</th>
-                        <th class="coral-Table-headerCell">Status</th>
-                        <th class="coral-Table-headerCell">Settings</th>
-                        <th class="coral-Table-headerCell">Actions</th>
-                    </tr>
-                </thead>
-
-                <tbody>
-                    <tr class="coral-Table-row" ng-repeat="task in tasks"
-                        ng-class="{ expanded : task.expanded }">
-                        <td class="coral-Table-cell">
-                            {{ task.id }}
-                        </td>
-
-                        <td class="coral-Table-cell">
-                            <div>{{ task.status.state }}</div>
-                            <div ng-show="task.expanded">
-
-                                <ul class="no-padding">
-                                    <li>Current path: {{ task.status.currentPath || 'N/A' }}</li>
-                                    <li>Last saved path:
-                                        {{ task.status.lastSavedPath || 'N/A' }}</li>
-                                    <li>Total nodes: {{ task.status.totalNodes }}</li>
-                                    <li>Total size: {{ task.status.totalSize }}</li>
-                                    <li>Current size: {{ task.status.currentSize }}</li>
-                                    <li>Current nodes: {{ task.status.currentNodes }}</li>
-                                </ul>
-                            </div>
-                        </td>
-                        <td class="coral-Table-cell">
-                            <ul class="no-padding">
-                                <li>Source: {{ task.src | removeCredentials
-                                    }}</li>
-                                <li>Destination: {{ task.dst }}</li>
+            <ul class="coral-Accordion coral-Collapsible--block tasks"  id="tasks">
+                <li class="coral-Accordion-item" 
+                    ng-class="{ 'is-active' :  task.expanded}"
+                    ng-repeat="task in tasks"
+                    ng-init="task.expanded = taskExpandedStatuses[$index]">
+                    <h3 class="coral-Accordion-header" 
+                        ng-click="taskExpandedStatuses[$index] = !taskExpandedStatuses[$index]; task.expanded = taskExpandedStatuses[$index]">
+                        <i class="coral-Icon coral-Icon--sizeS" ng-class="{'coral-Icon--chevronRight': !task.expanded, 'coral-Icon--chevronDown': task.expanded}"></i>
+                        <span class="coral-Accordion-title">{{ task.id }}</span>
+                        <span class="coral-Accordion-subtitle">{{ task.status.state }}</span>
+                        <!-- Task Action buttons -->
+                        <span class="task-actions">
+                            <button class="coral-Button--quiet"
+                                title="Create new duplicate task with this tasks values"
+                                ng-click="duplicate(task)"
+                                data-target="#create-new-task-modal"
+                                data-toggle="modal">
+                                <i  class="coral-Icon coral-Icon--sizeS coral-Icon--duplicate"></i>
+                            </button>
+                            <button class="coral-Button--quiet"
+                                title="Start task"
+                                ng-show="task.status.state == 'NEW'"
+                                ng-click="start(task)">
+                                <i class="coral-Icon coral-Icon--sizeS coral-Icon--playCircle"></i>
+                            </button>
+                            <button class="coral-Button--quiet"
+                                title="Stop task"
+                                ng-show="task.status.state == 'RUNNING'"
+                                ng-click="stop(task)">
+                                <i class="coral-Icon coral-Icon--sizeS coral-Icon--stopCircle"></i>
+                            </button>
+                            <button class="coral-Button--quiet"
+                                title="Delete Task"
+                                ng-click="remove(task)">
+                                <i class="coral-Icon coral-Icon--sizeS coral-Icon--delete"></i>
+                            </button>
+                        </span>
+                        <!-- // Task Action buttons -->
+                    </h3>
+                    <div class="coral-Accordion-content" ng-style="{'display' : task.expanded ? 'block' : 'none'}">
+                        
+                        <div class="task-status">
+                            <h3>Task Status</h3>
+                            <ul>
+                                <li><b>State:</b> {{ task.status.state }}</li>
+                                <li><b>Current path:</b> {{ task.status.currentPath || 'N/A' }}</li>
+                                <li><b>Last saved path:</b> {{ task.status.lastSavedPath || 'N/A' }}</li>
+                                <li><b>Total nodes:</b> {{ task.status.totalNodes }}</li>
+                                <li><b>Total size:</b> {{ task.status.totalSize }}</li>
+                                <li><b>Current size:</b> {{ task.status.currentSize }}</li>
+                                <li><b>Current nodes:</b> {{ task.status.currentNodes }}</li>
                             </ul>
+                        </div>
 
-                            <ul ng-show="task.expanded" class="no-padding">
-                                <li>Recursive: {{ task.recursive }}</li>
-                                <li>Batch size: {{ task.batchsize }}</li>
-                                <li>Update: {{ task.update }}</li>
-                                <li>Only newer: {{ task.onlyNewer }}</li>
-                                <li>No ordering: {{ task.noOrdering }}</li>
-                                <li>Throttle: {{ task.throttle || 0}} seconds</li>
-                                <li>Resume from: {{ task.resumeFrom || 'Not set'}}</li>
-
+                        <div class="task-settings">
+                            <h3>Task Settings</h3>
+                            <ul>
+                                <li><b>Source:</b> {{ task.src | removeCredentials }}</li>
+                                <li><b>Destination:</b> {{ task.dst }}</li>
+                                <li><b>Recursive:</b> {{ task.recursive }}</li>
+                                <li><b>Batch size:</b> {{ task.batchsize }}</li>
+                                <li><b>Update:</b> {{ task.update }}</li>
+                                <li><b>Only newer:</b> {{ task.onlyNewer }}</li>
+                                <li><b>No ordering:</b> {{ task.noOrdering }}</li>
+                                <li><b>Throttle:</b> {{ task.throttle || 0}} seconds</li>
+                                <li><b>Resume from:</b> {{ task.resumeFrom || 'Not set'}}</li>
                                 <li ng-show="task.excludes.length > 0">
                                     Excludes:
                                     <ul>
@@ -155,41 +173,12 @@
                                     </ul>
                                 </li>
                             </ul>
-                        </td>
-                        <td class="coral-Table-cell actions">
-                            <button class="coral-Button coral-Button--square coral-Button--quiet"
-                                ng-click="task.expanded = !task.expanded">
-                              <i class="coral-Icon" ng-class="task.expanded ? 'coral-Icon--treeCollapse' : 'coral-Icon--treeExpand'"></i>
-                            </button>
-                            <button class="coral-Button coral-Button--square coral-Button--quiet"
-                                ng-click="duplicate(task)"
-                                data-target="#create-new-task-modal"
-                                data-toggle="modal">
-                                <i  class="coral-Icon coral-Icon--duplicate"
-                                    data-init="quicktip" 
-                                    data-quicktip-type="info" 
-                                    data-quicktip-arrow="top" 
-                                    data-quicktip-content="New duplicate task"></i>
-                            </button>
-                            <button class="coral-Button coral-Button--square coral-Button--quiet"
-                                ng-show="task.status.state == 'NEW'"
-                                ng-click="start(task)">
-                              <i class="coral-Icon coral-Icon--playCircle"></i>
-                            </button>
-                            <button class="coral-Button coral-Button--square coral-Button--quiet"
-                                ng-show="task.status.state == 'RUNNING'"
-                                ng-click="stop(task)">
-                              <i class="coral-Icon coral-Icon--stopCircle"></i>
-                            </button>
-                            <button class="coral-Button coral-Button--square coral-Button--quiet"
-                                ng-click="remove(task)">
-                              <i class="coral-Icon coral-Icon--delete"></i>
-                            </button>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        </div>
+                    </div>
+                </li>
+            </ul>
         </div>
+        <!-- // Tasks accordion section -->
 
         <cq:include script="includes/create-task-modal.jsp"/>
     </div>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/content.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/content.jsp
@@ -99,6 +99,9 @@
             <p>
                 Click on the <i class="coral-Icon coral-Icon--duplicate"></i> icon to create a new task with duplicate values.
             </p>
+            <p>
+                When the "<i class="coral-Icon coral-Icon--refresh"></i> Auto Refresh" button is enabled, tasks will flash to indicate an update
+            </p>
 
             <ul class="coral-Accordion coral-Collapsible--block tasks"  id="tasks">
                 <li class="coral-Accordion-item" 
@@ -109,7 +112,9 @@
                         ng-click="taskExpandedStatuses[$index] = !taskExpandedStatuses[$index]; task.expanded = taskExpandedStatuses[$index]">
                         <i class="coral-Icon coral-Icon--sizeS" ng-class="{'coral-Icon--chevronRight': !task.expanded, 'coral-Icon--chevronDown': task.expanded}"></i>
                         <span class="coral-Accordion-title">{{ task.id }}</span>
-                        <span class="coral-Accordion-subtitle">{{ task.status.state }}</span>
+                        <span class="coral-Accordion-subtitle">
+                            status: {{ task.status.state }} | <b>src: </b>{{ task.src | removeCredentials | truncate:50 }} | <b>dest: </b> {{ task.dst  | truncate:50 }}
+                        </span>
                         <!-- Task Action buttons -->
                         <span class="task-actions">
                             <button class="coral-Button--quiet"
@@ -138,6 +143,7 @@
                             </button>
                         </span>
                         <!-- // Task Action buttons -->
+                        <br/>
                     </h3>
                     <div class="coral-Accordion-content" ng-style="{'display' : task.expanded ? 'block' : 'none'}">
                         
@@ -157,7 +163,7 @@
                         <div class="task-settings">
                             <h3>Task Settings</h3>
                             <ul>
-                                <li><b>Source:</b> {{ task.src | removeCredentials }}</li>
+                                <li><b>Source:</b> {{ task.src | removeCredentials}}</li>
                                 <li><b>Destination:</b> {{ task.dst }}</li>
                                 <li><b>Recursive:</b> {{ task.recursive }}</li>
                                 <li><b>Batch size:</b> {{ task.batchsize }}</li>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/content.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/content.jsp
@@ -162,6 +162,16 @@
                               <i class="coral-Icon" ng-class="task.expanded ? 'coral-Icon--treeCollapse' : 'coral-Icon--treeExpand'"></i>
                             </button>
                             <button class="coral-Button coral-Button--square coral-Button--quiet"
+                                ng-click="duplicate(task)"
+                                data-target="#create-new-task-modal"
+                                data-toggle="modal">
+                                <i  class="coral-Icon coral-Icon--duplicate"
+                                    data-init="quicktip" 
+                                    data-quicktip-type="info" 
+                                    data-quicktip-arrow="top" 
+                                    data-quicktip-content="New duplicate task"></i>
+                            </button>
+                            <button class="coral-Button coral-Button--square coral-Button--quiet"
                                 ng-show="task.status.state == 'NEW'"
                                 ng-click="start(task)">
                               <i class="coral-Icon coral-Icon--playCircle"></i>

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-modal.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-modal.jsp
@@ -17,7 +17,7 @@
   ~ limitations under the License.
   ~ #L%
   --%>
-<div id="create-new-task-modal" class="coral-Modal coral-Modal--fullscreen" data-fullscreen="true">
+<div id="create-new-task-modal" class="coral-Modal">
 
     <div class="coral-Modal-header">
         <i class="coral-Modal-typeIcon coral-Icon coral-Icon--sizeS"></i>
@@ -31,7 +31,23 @@
 
         <form name="myForm" class="coral-Form coral-Form--aligned" autocomplete="off" novalidate>
             <section class="create-new-task">
-                <!-- Credintial Fields, keep at top to avoid issues with password managers -->
+
+                <div class="coral-Form-fieldwrapper">
+                    <label class="coral-Form-fieldlabel">Task Id</label>
+                    <input class="coral-Form-field coral-Textfield" type="text"
+                            ng-model="task_id"
+                            name="task_id"/>
+                </div>
+
+                <div class="coral-Form-fieldwrapper">
+                    <label class="coral-Form-fieldlabel">Source</label>
+                    <input class="coral-Form-field coral-Textfield" type="text"
+                            ng-model="task_src"
+                            name="src"
+                            placeholder="http://localhost:4502/crx/server/-/jcr:root/content/dam/my-site"/>
+                </div>
+
+                <!-- Credintial Fields -->
                 <div class="coral-Form-fieldwrapper">
                     <label class="coral-Form-fieldlabel">Source User Name</label>
                     <input class="coral-Form-field coral-Textfield" type="text"
@@ -53,21 +69,6 @@
                             ng-model="showpassword"><span class="coral-Switch-offLabel">No</span><span class="coral-Switch-onLabel">Yes</span>
                 </span>
                 <!-- // Credintial Fields -->
-                
-                <div class="coral-Form-fieldwrapper">
-                    <label class="coral-Form-fieldlabel">Task Id</label>
-                    <input class="coral-Form-field coral-Textfield" type="text"
-                            ng-model="task_id"
-                            name="task_id"/>
-                </div>
-
-                <div class="coral-Form-fieldwrapper">
-                    <label class="coral-Form-fieldlabel">Source</label>
-                    <input class="coral-Form-field coral-Textfield" type="text"
-                            ng-model="task_src"
-                            name="src"
-                            placeholder="http://localhost:4502/crx/server/-/jcr:root/content/dam/my-site"/>
-                </div>
 
                 <!-- Switch Options -->
                 <label class="coral-Form-fieldlabel">Destination</label>
@@ -126,8 +127,8 @@
 
                 <label class="coral-Form-fieldlabel">Excludes</label>
                 <div class="coral-Form-field excludes">
-                    <a class="coral-Button" ng-click="addExclude()">
-                        <i class="coral-Icon coral-Icon--addCircle"></i> Add Exclude Rule
+                    <a class="addButton" ng-click="addExclude()">
+                        <i class="coral-Icon coral-Icon--addCircle"></i>
                     </a>
                     <div class="add-remove-list" ng-show="excludes.length > 0">
                         <ul ng-repeat="exclude in excludes track by $index">

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-modal.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-modal.jsp
@@ -17,7 +17,7 @@
   ~ limitations under the License.
   ~ #L%
   --%>
-<div id="create-new-task-modal" class="coral-Modal">
+<div id="create-new-task-modal" class="coral-Modal coral-Modal--fullscreen" data-fullscreen="true">
 
     <div class="coral-Modal-header">
         <i class="coral-Modal-typeIcon coral-Icon coral-Icon--sizeS"></i>
@@ -29,40 +29,45 @@
 
     <div class="coral-Modal-body">
 
-        <form name="myForm" class="coral-Form coral-Form--aligned">
+        <form name="myForm" class="coral-Form coral-Form--aligned" autocomplete="off" novalidate>
             <section class="create-new-task">
-
-                <label class="coral-Form-fieldlabel">Task Id</label>
-                <input class="coral-Form-field coral-Textfield" type="text"
-                       ng-model="task_id"
-                       name="id"/>
-                
-                <!-- Credintial Fields -->
-                <label class="coral-Form-fieldlabel">Source</label>
-                <input class="coral-Form-field coral-Textfield" type="text"
-                       ng-model="task_src"
-                       name="src"
-                       placeholder="http://localhost:4502/crx/server/-/jcr:root/content/dam/my-site"/>
+                <!-- Credintial Fields, keep at top to avoid issues with password managers -->
                 <div class="coral-Form-fieldwrapper">
                     <label class="coral-Form-fieldlabel">Source User Name</label>
                     <input class="coral-Form-field coral-Textfield" type="text"
-                           ng-model="task_src_username"
-                           name="username"/>
+                            autocomplete="username"
+                            ng-model="task_src_username"
+                            name="username"/>
                 </div>
 
                 <div class="coral-Form-fieldwrapper">
                     <label class="coral-Form-fieldlabel">Source Password</label>
                     <input class="coral-Form-field coral-Textfield" ng-attr-type="{{showpassword ? 'text' : 'password'}}"
-                           ng-model="task_src_password"
-                           name="passsword"/>
+                            ng-model="task_src_password"
+                            name="passsword"/>
                 </div>
                 <label class="coral-Form-fieldlabel">Show Password</label>
                 <span class="coral-Form-field coral-Switch">
                     <input class="coral-Switch-input" type="checkbox"
-                           name="showpassword"
-                           ng-model="showpassword"><span class="coral-Switch-offLabel">No</span><span class="coral-Switch-onLabel">Yes</span>
+                            name="showpassword"
+                            ng-model="showpassword"><span class="coral-Switch-offLabel">No</span><span class="coral-Switch-onLabel">Yes</span>
                 </span>
                 <!-- // Credintial Fields -->
+                
+                <div class="coral-Form-fieldwrapper">
+                    <label class="coral-Form-fieldlabel">Task Id</label>
+                    <input class="coral-Form-field coral-Textfield" type="text"
+                            ng-model="task_id"
+                            name="task_id"/>
+                </div>
+
+                <div class="coral-Form-fieldwrapper">
+                    <label class="coral-Form-fieldlabel">Source</label>
+                    <input class="coral-Form-field coral-Textfield" type="text"
+                            ng-model="task_src"
+                            name="src"
+                            placeholder="http://localhost:4502/crx/server/-/jcr:root/content/dam/my-site"/>
+                </div>
 
                 <!-- Switch Options -->
                 <label class="coral-Form-fieldlabel">Destination</label>
@@ -121,8 +126,8 @@
 
                 <label class="coral-Form-fieldlabel">Excludes</label>
                 <div class="coral-Form-field excludes">
-                    <a class="addButton" ng-click="addExclude()">
-                        <i class="coral-Icon coral-Icon--addCircle"></i>
+                    <a class="coral-Button" ng-click="addExclude()">
+                        <i class="coral-Icon coral-Icon--addCircle"></i> Add Exclude Rule
                     </a>
                     <div class="add-remove-list" ng-show="excludes.length > 0">
                         <ul ng-repeat="exclude in excludes track by $index">

--- a/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-modal.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-tools/components/vlt-rcp/includes/create-task-modal.jsp
@@ -36,22 +36,35 @@
                 <input class="coral-Form-field coral-Textfield" type="text"
                        ng-model="task_id"
                        name="id"/>
-
+                
+                <!-- Credintial Fields -->
                 <label class="coral-Form-fieldlabel">Source</label>
                 <input class="coral-Form-field coral-Textfield" type="text"
                        ng-model="task_src"
                        name="src"
                        placeholder="http://localhost:4502/crx/server/-/jcr:root/content/dam/my-site"/>
                 <div class="coral-Form-fieldwrapper">
-                    <label class="coral-Form-fieldlabel">Source Credentials
-                    </label>
-                    <input class="coral-Form-field coral-Textfield" type="password"
-                           ng-model="task_src_credentials"
-                           name="src_password"
-                    /> <span class="coral-Form-fieldinfo coral-Icon coral-Icon--infoCircle coral-Icon--sizeS" data-init="quicktip" data-quicktip-type="info" data-quicktip-arrow="right" data-quicktip-content="userid:password"></span>
+                    <label class="coral-Form-fieldlabel">Source User Name</label>
+                    <input class="coral-Form-field coral-Textfield" type="text"
+                           ng-model="task_src_username"
+                           name="username"/>
                 </div>
 
+                <div class="coral-Form-fieldwrapper">
+                    <label class="coral-Form-fieldlabel">Source Password</label>
+                    <input class="coral-Form-field coral-Textfield" ng-attr-type="{{showpassword ? 'text' : 'password'}}"
+                           ng-model="task_src_password"
+                           name="passsword"/>
+                </div>
+                <label class="coral-Form-fieldlabel">Show Password</label>
+                <span class="coral-Form-field coral-Switch">
+                    <input class="coral-Switch-input" type="checkbox"
+                           name="showpassword"
+                           ng-model="showpassword"><span class="coral-Switch-offLabel">No</span><span class="coral-Switch-onLabel">Yes</span>
+                </span>
+                <!-- // Credintial Fields -->
 
+                <!-- Switch Options -->
                 <label class="coral-Form-fieldlabel">Destination</label>
                 <input class="coral-Form-field coral-Textfield" type="text"
                        ng-model="task_dst"
@@ -85,7 +98,9 @@
                            name="noOrdering"
                            ng-model="checkboxModel.noOrdering"><span class="coral-Switch-offLabel">No</span><span class="coral-Switch-onLabel">Yes</span>
                 </span>
+                <!-- // Switch Options -->
 
+                <!-- Extra Options -->
                 <label class="coral-Form-fieldlabel">Resume from</label>
                 <input class="coral-Form-field coral-Textfield" type="text"
                        ng-model="task_resumeFrom"
@@ -121,6 +136,7 @@
                         </ul>
                     </div>
                 </div>
+                <!-- // Extra Options -->
             </section>
         </form>
     </div>


### PR DESCRIPTION
This PR include the following:

1. **New Features**
   - Additional action button to duplicate an existing task. Ie. create a new task based on an existing task's values, but with a new ID. Since editing a task is not an option, this is very handy when a user makes a mistake or just does not want to re-add al the field values
2. **UI enhancements**
   - The previous UI used a table and bullet lists. Also, upon expanding a task, the UI shifts to adjust to the new text making it hard to follow. This PR uses an accordion instead. All visible labels/values are the same, just presented in a better way that keeps the values where they are.
   - The previous UI did not respect expanded tasks when the auto-refresh button is on. This PR keeps the expanded tasks expanded even after the tasks have been updated (refreshed)
   - Added small space between the auto-refresh text and icon
   - removed the explanation for the expand/collapse icon as that was removed in favor of an accordion
3. **Bug fixes**
   - The `removeCredentials` filters was throwing `undefined` errors. does not affect user experience but fixed nonetheless.
4. **Code Format and comments**
   - Fixed some HTML formats and added comments where I could (in both HTML and JS)

<img width="1011" alt="screen shot 2018-06-17 at 1 36 07 am" src="https://user-images.githubusercontent.com/13037215/41505430-e47c72fc-71ce-11e8-9a5d-d821b62bc5a9.png">
<img width="983" alt="screen shot 2018-06-17 at 1 36 18 am" src="https://user-images.githubusercontent.com/13037215/41505431-e48e59d6-71ce-11e8-8a8d-e80a9c1d03a0.png">

